### PR TITLE
Add rectangular stencil variants

### DIFF
--- a/include/geometry/stencil.h
+++ b/include/geometry/stencil.h
@@ -50,8 +50,27 @@ struct GeneralStencil {
 // Create a custom N-pole stencil in D dimensions (user provides offsets and weights, can provide a state resolver)
 GeneralStencil* stencil_create_custom(size_t dims, size_t count, const int* offsets, const double* weights, StencilStateResolver resolver, void* resolver_data);
 
-// Create a D-dimensional rectangular stencil of given radius (axis-aligned)
-GeneralStencil* stencil_create_rectangular_nd(size_t dims, int radius);
+// Common rectangular stencil variants
+typedef enum {
+    // Default axis-aligned cross (6 point in 3D, 5 point in 2D, etc.)
+    RECT_STENCIL_DEFAULT = 0,
+    // Axis-aligned neighbours only (2*d points)
+    RECT_STENCIL_AXIS_ALIGNED,
+    // Axis-aligned neighbours plus centre (2*d + 1)
+    RECT_STENCIL_AXIS_ALIGNED_WITH_CENTER,
+    // Full box without centre ( (2*radius+1)^d - 1 )
+    RECT_STENCIL_FULL,
+    // Full box including centre ( (2*radius+1)^d )
+    RECT_STENCIL_FULL_WITH_CENTER,
+    // Classical 14 point stencil in 3D (axis + face diagonals)
+    RECT_STENCIL_14_POINT_3D,
+    // 24-cell vertices in 4D (\u00b11,\u00b11,0,0 permutations)
+    RECT_STENCIL_24_CELL_4D
+} RectangularStencilType;
+
+// Create a D-dimensional rectangular stencil of given radius and pattern
+GeneralStencil* stencil_create_rectangular_nd(size_t dims, int radius,
+                                              RectangularStencilType type);
 
 // Create a D-dimensional polar (equidistant) stencil of given radius (Euclidean distance)
 GeneralStencil* stencil_create_polar_nd(size_t dims, int radius);

--- a/src/geometry/stencil.c
+++ b/src/geometry/stencil.c
@@ -66,9 +66,140 @@ GeneralStencil* stencil_create_custom(size_t dims, size_t count, const int* offs
     return s;
 }
 
-GeneralStencil* stencil_create_rectangular_nd(size_t dims, int radius) {
-    // TODO: Implement D-dimensional rectangular stencil
-    return NULL;
+static size_t pow_size(size_t base, size_t exp) {
+    size_t r = 1;
+    for (size_t i = 0; i < exp; ++i) r *= base;
+    return r;
+}
+
+static int is_zero_vec(const int* v, size_t dims) {
+    for (size_t i = 0; i < dims; ++i)
+        if (v[i] != 0) return 0;
+    return 1;
+}
+
+GeneralStencil* stencil_create_rectangular_nd(size_t dims, int radius,
+                                              RectangularStencilType type) {
+    if (dims == 0 || radius <= 0) return NULL;
+
+    if (type == RECT_STENCIL_DEFAULT) {
+        if (dims == 2)
+            type = RECT_STENCIL_AXIS_ALIGNED_WITH_CENTER; // 5-point
+        else
+            type = RECT_STENCIL_AXIS_ALIGNED; // 6-point in 3D, 8-point in 4D
+    }
+
+    size_t count = 0;
+    switch (type) {
+        case RECT_STENCIL_AXIS_ALIGNED:
+            count = dims * 2 * radius;
+            break;
+        case RECT_STENCIL_AXIS_ALIGNED_WITH_CENTER:
+            count = dims * 2 * radius + 1;
+            break;
+        case RECT_STENCIL_FULL:
+            count = pow_size(2 * radius + 1, dims) - 1;
+            break;
+        case RECT_STENCIL_FULL_WITH_CENTER:
+            count = pow_size(2 * radius + 1, dims);
+            break;
+        case RECT_STENCIL_14_POINT_3D:
+            if (dims != 3 || radius != 1) return NULL;
+            count = 14;
+            break;
+        case RECT_STENCIL_24_CELL_4D:
+            if (dims != 4 || radius != 1) return NULL;
+            count = 24;
+            break;
+        default:
+            return NULL;
+    }
+
+    GeneralStencil* s = (GeneralStencil*)calloc(1, sizeof(GeneralStencil));
+    s->poles = (StencilPole*)calloc(count, sizeof(StencilPole));
+    s->count = count;
+    s->dims = dims;
+
+    size_t idx = 0;
+
+    if (type == RECT_STENCIL_AXIS_ALIGNED ||
+        type == RECT_STENCIL_AXIS_ALIGNED_WITH_CENTER) {
+        for (size_t d = 0; d < dims; ++d) {
+            for (int r = 1; r <= radius; ++r) {
+                s->poles[idx].offsets = (int*)calloc(dims, sizeof(int));
+                s->poles[idx].dims = dims;
+                s->poles[idx].offsets[d] = r;
+                s->poles[idx++].weight = 1.0;
+
+                s->poles[idx].offsets = (int*)calloc(dims, sizeof(int));
+                s->poles[idx].dims = dims;
+                s->poles[idx].offsets[d] = -r;
+                s->poles[idx++].weight = 1.0;
+            }
+        }
+        if (type == RECT_STENCIL_AXIS_ALIGNED_WITH_CENTER) {
+            s->poles[idx].offsets = (int*)calloc(dims, sizeof(int));
+            s->poles[idx].dims = dims;
+            s->poles[idx].weight = 1.0;
+            idx++;
+        }
+    } else if (type == RECT_STENCIL_FULL ||
+               type == RECT_STENCIL_FULL_WITH_CENTER) {
+        int* cur = (int*)calloc(dims, sizeof(int));
+        for (size_t i = 0; i < dims; ++i) cur[i] = -radius;
+        int done = 0;
+        while (!done) {
+            if (type == RECT_STENCIL_FULL_WITH_CENTER || !is_zero_vec(cur, dims)) {
+                s->poles[idx].offsets = (int*)calloc(dims, sizeof(int));
+                s->poles[idx].dims = dims;
+                for (size_t d = 0; d < dims; ++d)
+                    s->poles[idx].offsets[d] = cur[d];
+                s->poles[idx++].weight = 1.0;
+            }
+            for (size_t d = 0; d < dims; ++d) {
+                cur[d]++;
+                if (cur[d] <= radius) break;
+                cur[d] = -radius;
+                if (d == dims - 1) done = 1;
+            }
+        }
+        free(cur);
+    } else if (type == RECT_STENCIL_14_POINT_3D) {
+        static const int dirs[6][3] = {
+            {1,0,0},{-1,0,0},{0,1,0},{0,-1,0},{0,0,1},{0,0,-1}
+        };
+        for (int i = 0; i < 6; ++i) {
+            s->poles[idx].offsets = (int*)calloc(3, sizeof(int));
+            s->poles[idx].dims = 3;
+            memcpy(s->poles[idx].offsets, dirs[i], 3*sizeof(int));
+            s->poles[idx++].weight = 1.0;
+        }
+        static const int diags[8][3] = {
+            {1,1,1},{1,1,-1},{1,-1,1},{1,-1,-1},
+            {-1,1,1},{-1,1,-1},{-1,-1,1},{-1,-1,-1}
+        };
+        for (int i = 0; i < 8; ++i) {
+            s->poles[idx].offsets = (int*)calloc(3, sizeof(int));
+            s->poles[idx].dims = 3;
+            memcpy(s->poles[idx].offsets, diags[i], 3*sizeof(int));
+            s->poles[idx++].weight = 1.0;
+        }
+    } else if (type == RECT_STENCIL_24_CELL_4D) {
+        int pairs[6][2] = {{0,1},{0,2},{0,3},{1,2},{1,3},{2,3}};
+        for (int p = 0; p < 6; ++p) {
+            for (int sx = -1; sx <= 1; sx += 2) {
+                for (int sy = -1; sy <= 1; sy += 2) {
+                    s->poles[idx].offsets = (int*)calloc(4, sizeof(int));
+                    s->poles[idx].dims = 4;
+                    s->poles[idx].offsets[pairs[p][0]] = sx;
+                    s->poles[idx].offsets[pairs[p][1]] = sy;
+                    s->poles[idx++].weight = 1.0;
+                }
+            }
+        }
+    }
+
+    return s;
 }
 
 GeneralStencil* stencil_create_polar_nd(size_t dims, int radius) {


### PR DESCRIPTION
## Summary
- extend the stencil interface with a set of rectangular patterns
- implement `stencil_create_rectangular_nd` with support for axis, full, 14‑point and 4‑D 24‑cell stencils

## Testing
- `cmake ..`
- `make -j$(nproc)` *(fails: conflicting struct definitions in unrelated modules)*

------
https://chatgpt.com/codex/tasks/task_e_6859e3587840832a97f23e3bb9642302