### PR TITLE
Add GraphOpsHandler abstraction

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,3 +28,7 @@ enable_testing()
 add_executable(utils_test tests/utils_test.c)
 target_link_libraries(utils_test geometry)
 add_test(NAME utils_test COMMAND utils_test)
+
+add_executable(graph_ops_handler_test tests/graph_ops_handler_test.c)
+target_link_libraries(graph_ops_handler_test geometry)
+add_test(NAME graph_ops_handler_test COMMAND graph_ops_handler_test)

--- a/include/geometry/graph_ops_handler.h
+++ b/include/geometry/graph_ops_handler.h
@@ -1,0 +1,105 @@
+#ifndef GEOMETRY_GRAPH_OPS_HANDLER_H
+#define GEOMETRY_GRAPH_OPS_HANDLER_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include "geometry/graph_ops.h"
+
+/* Error codes for GraphOpsHandler */
+#define GRAPH_OPS_OK 0
+#define GRAPH_OPS_ERR -1
+
+/*
+ * GraphOpsHandler provides a thin indirection layer over a GraphOps table.
+ * It allows containers to register their operation implementations and
+ * clients to call the standard GraphOps interface with built-in null
+ * checks. If a particular function pointer is not provided, the wrapper
+ * returns GRAPH_OPS_ERR (or NULL for pointer-returning operations).
+ */
+typedef struct {
+    const GraphOps* ops;
+} GraphOpsHandler;
+
+static inline int graph_ops_handler_init(GraphOpsHandler* h, const GraphOps* ops) {
+    if (!h) return GRAPH_OPS_ERR;
+    h->ops = ops;
+    return GRAPH_OPS_OK;
+}
+
+static inline int graph_ops_push(const GraphOpsHandler* h, Node* n, Node* child) {
+    if (!h || !h->ops || !h->ops->push) return GRAPH_OPS_ERR;
+    h->ops->push(n, child);
+    return GRAPH_OPS_OK;
+}
+
+static inline Node* graph_ops_pop(const GraphOpsHandler* h, Node* n) {
+    return (!h || !h->ops || !h->ops->pop) ? NULL : h->ops->pop(n);
+}
+
+static inline Node* graph_ops_shift(const GraphOpsHandler* h, Node* n) {
+    return (!h || !h->ops || !h->ops->shift) ? NULL : h->ops->shift(n);
+}
+
+static inline int graph_ops_unshift(const GraphOpsHandler* h, Node* n, Node* child) {
+    if (!h || !h->ops || !h->ops->unshift) return GRAPH_OPS_ERR;
+    h->ops->unshift(n, child);
+    return GRAPH_OPS_OK;
+}
+
+static inline Node* graph_ops_get(const GraphOpsHandler* h, Node* n, size_t idx) {
+    return (!h || !h->ops || !h->ops->get) ? NULL : h->ops->get(n, idx);
+}
+
+static inline size_t graph_ops_size(const GraphOpsHandler* h, Node* n) {
+    return (!h || !h->ops || !h->ops->size) ? 0 : h->ops->size(n);
+}
+
+static inline int graph_ops_sort(const GraphOpsHandler* h, Node* n,
+                                 int (*cmp)(const Node*, const Node*)) {
+    if (!h || !h->ops || !h->ops->sort) return GRAPH_OPS_ERR;
+    h->ops->sort(n, cmp);
+    return GRAPH_OPS_OK;
+}
+
+static inline Node* graph_ops_search(const GraphOpsHandler* h, Node* n,
+                                     int (*pred)(const Node*, void*), void* user) {
+    return (!h || !h->ops || !h->ops->search) ? NULL : h->ops->search(n, pred, user);
+}
+
+static inline Node* graph_ops_left(const GraphOpsHandler* h, Node* n) {
+    return (!h || !h->ops || !h->ops->left) ? NULL : h->ops->left(n);
+}
+
+static inline Node* graph_ops_right(const GraphOpsHandler* h, Node* n) {
+    return (!h || !h->ops || !h->ops->right) ? NULL : h->ops->right(n);
+}
+
+static inline Node* graph_ops_up(const GraphOpsHandler* h, Node* n) {
+    return (!h || !h->ops || !h->ops->up) ? NULL : h->ops->up(n);
+}
+
+static inline Node* graph_ops_down(const GraphOpsHandler* h, Node* n) {
+    return (!h || !h->ops || !h->ops->down) ? NULL : h->ops->down(n);
+}
+
+static inline int graph_ops_slice(const GraphOpsHandler* h, Node* n,
+                                  size_t start, size_t end, Node** out) {
+    if (!h || !h->ops || !h->ops->slice) return GRAPH_OPS_ERR;
+    h->ops->slice(n, start, end, out);
+    return GRAPH_OPS_OK;
+}
+
+static inline int graph_ops_stencil(const GraphOpsHandler* h, Node* n,
+                                    const size_t* indices, size_t count, Node** out) {
+    if (!h || !h->ops || !h->ops->stencil) return GRAPH_OPS_ERR;
+    h->ops->stencil(n, indices, count, out);
+    return GRAPH_OPS_OK;
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* GEOMETRY_GRAPH_OPS_HANDLER_H */

--- a/tests/graph_ops_handler_test.c
+++ b/tests/graph_ops_handler_test.c
@@ -1,0 +1,38 @@
+#include "geometry/graph_ops_handler.h"
+#include <assert.h>
+#include <stdio.h>
+
+static int push_called = 0;
+static int pop_called = 0;
+
+static void dummy_push(Node* n, Node* c) {
+    (void)n; (void)c; push_called++;
+}
+
+static Node* dummy_pop(Node* n) {
+    pop_called++; return n;
+}
+
+int main(void) {
+    GraphOps ops = {0};
+    ops.push = dummy_push;
+    ops.pop = dummy_pop;
+    GraphOpsHandler h;
+    assert(graph_ops_handler_init(&h, &ops) == GRAPH_OPS_OK);
+
+    Node node = {0};
+    Node child = {0};
+
+    assert(graph_ops_push(&h, &node, &child) == GRAPH_OPS_OK);
+    assert(push_called == 1);
+
+    Node* ret = graph_ops_pop(&h, &node);
+    assert(ret == &node && pop_called == 1);
+
+    /* Call a missing op */
+    ret = graph_ops_shift(&h, &node);
+    assert(ret == NULL);
+
+    printf("graph_ops_handler_test passed\n");
+    return 0;
+}


### PR DESCRIPTION
## Summary
- add a GraphOpsHandler helper for routing operations
- wrap GraphOps calls with null checks
- provide a minimal test showing usage
- register the new test in CMake

## Testing
- `cmake ..`
- `make -j$(nproc)` (fails to compile due to existing errors)

------
https://chatgpt.com/codex/tasks/task_e_685b429d2a2c832a806b643b53fadeaf