### PR TITLE
Unify handler includes and add stub implementations

### DIFF
--- a/include/geometry/graph_ops.h
+++ b/include/geometry/graph_ops.h
@@ -50,10 +50,13 @@ typedef enum {
 	NODE_FEATURE_TYPE_MEMORY_TOKEN = 39, // Memory token feature type
 	NODE_FEATURE_TYPE_TOKEN_LOCK = 40, // Token lock feature type
 	NODE_FEATURE_TYPE_MEMORY_MAP = 41, // Memory map feature type
-	NODE_FEATURE_TYPE_MESSAGE = 42, // Guardian message feature type
-	NODE_FEATURE_TYPE_CUSTOM = 43, // Custom feature type for user-defined features
-
+        NODE_FEATURE_TYPE_MESSAGE = 42, // Guardian message feature type
+        NODE_FEATURE_TYPE_CUSTOM = 43, // Custom feature type for user-defined features
+        NODE_FEATURE_TYPE_COUNT
 } NodeFeatureType;
+
+/* Alias for compatibility with the operation suite API */
+typedef NodeFeatureType OperationSuiteType;
 
 
 /* Generic function-pointer typedefs for container operations */

--- a/include/geometry/graph_ops_boolean.h
+++ b/include/geometry/graph_ops_boolean.h
@@ -1,0 +1,9 @@
+#ifndef GEOMETRY_GRAPH_OPS_BOOLEAN_H
+#define GEOMETRY_GRAPH_OPS_BOOLEAN_H
+
+#include "geometry/graph_ops.h"
+
+/* Stub operation suite for boolean */
+extern const OperationSuite graph_ops_boolean;
+
+#endif /* GEOMETRY_GRAPH_OPS_BOOLEAN_H */

--- a/include/geometry/graph_ops_custom.h
+++ b/include/geometry/graph_ops_custom.h
@@ -1,0 +1,9 @@
+#ifndef GEOMETRY_GRAPH_OPS_CUSTOM_H
+#define GEOMETRY_GRAPH_OPS_CUSTOM_H
+
+#include "geometry/graph_ops.h"
+
+/* Stub operation suite for custom */
+extern const OperationSuite graph_ops_custom;
+
+#endif /* GEOMETRY_GRAPH_OPS_CUSTOM_H */

--- a/include/geometry/graph_ops_dictionary.h
+++ b/include/geometry/graph_ops_dictionary.h
@@ -1,0 +1,9 @@
+#ifndef GEOMETRY_GRAPH_OPS_DICTIONARY_H
+#define GEOMETRY_GRAPH_OPS_DICTIONARY_H
+
+#include "geometry/graph_ops.h"
+
+/* Stub operation suite for dictionary */
+extern const OperationSuite graph_ops_dictionary;
+
+#endif /* GEOMETRY_GRAPH_OPS_DICTIONARY_H */

--- a/include/geometry/graph_ops_double.h
+++ b/include/geometry/graph_ops_double.h
@@ -1,0 +1,9 @@
+#ifndef GEOMETRY_GRAPH_OPS_DOUBLE_H
+#define GEOMETRY_GRAPH_OPS_DOUBLE_H
+
+#include "geometry/graph_ops.h"
+
+/* Stub operation suite for double */
+extern const OperationSuite graph_ops_double;
+
+#endif /* GEOMETRY_GRAPH_OPS_DOUBLE_H */

--- a/include/geometry/graph_ops_edge.h
+++ b/include/geometry/graph_ops_edge.h
@@ -1,0 +1,9 @@
+#ifndef GEOMETRY_GRAPH_OPS_EDGE_H
+#define GEOMETRY_GRAPH_OPS_EDGE_H
+
+#include "geometry/graph_ops.h"
+
+/* Stub operation suite for edge */
+extern const OperationSuite graph_ops_edge;
+
+#endif /* GEOMETRY_GRAPH_OPS_EDGE_H */

--- a/include/geometry/graph_ops_emergence.h
+++ b/include/geometry/graph_ops_emergence.h
@@ -1,0 +1,9 @@
+#ifndef GEOMETRY_GRAPH_OPS_EMERGENCE_H
+#define GEOMETRY_GRAPH_OPS_EMERGENCE_H
+
+#include "geometry/graph_ops.h"
+
+/* Stub operation suite for emergence */
+extern const OperationSuite graph_ops_emergence;
+
+#endif /* GEOMETRY_GRAPH_OPS_EMERGENCE_H */

--- a/include/geometry/graph_ops_float.h
+++ b/include/geometry/graph_ops_float.h
@@ -1,0 +1,9 @@
+#ifndef GEOMETRY_GRAPH_OPS_FLOAT_H
+#define GEOMETRY_GRAPH_OPS_FLOAT_H
+
+#include "geometry/graph_ops.h"
+
+/* Stub operation suite for float */
+extern const OperationSuite graph_ops_float;
+
+#endif /* GEOMETRY_GRAPH_OPS_FLOAT_H */

--- a/include/geometry/graph_ops_genealogy.h
+++ b/include/geometry/graph_ops_genealogy.h
@@ -1,0 +1,9 @@
+#ifndef GEOMETRY_GRAPH_OPS_GENEALOGY_H
+#define GEOMETRY_GRAPH_OPS_GENEALOGY_H
+
+#include "geometry/graph_ops.h"
+
+/* Stub operation suite for genealogy */
+extern const OperationSuite graph_ops_genealogy;
+
+#endif /* GEOMETRY_GRAPH_OPS_GENEALOGY_H */

--- a/include/geometry/graph_ops_guardian.h
+++ b/include/geometry/graph_ops_guardian.h
@@ -1,0 +1,9 @@
+#ifndef GEOMETRY_GRAPH_OPS_GUARDIAN_H
+#define GEOMETRY_GRAPH_OPS_GUARDIAN_H
+
+#include "geometry/graph_ops.h"
+
+/* Stub operation suite for guardian */
+extern const OperationSuite graph_ops_guardian;
+
+#endif /* GEOMETRY_GRAPH_OPS_GUARDIAN_H */

--- a/include/geometry/graph_ops_handler.h
+++ b/include/geometry/graph_ops_handler.h
@@ -7,171 +7,51 @@ extern "C" {
 
 #include "geometry/graph_ops.h"
 
-/* Auto-detect and include suite implementation headers */
-#if defined(__has_include)
-  #if __has_include("geometry/graph_ops_int.h")
-    #include "geometry/graph_ops_int.h"
-    #define HAS_OP_SUITE_INT
-  #endif
-  #if __has_include("geometry/graph_ops_uint.h")
-    #include "geometry/graph_ops_uint.h"
-    #define HAS_OP_SUITE_UINT
-  #endif
-  /* Repeat for other primitive suite headers */
-  #if __has_include("geometry/graph_ops_node.h")
-    #include "geometry/graph_ops_node.h"
-    #define HAS_OP_SUITE_NODE
-  #endif
-  #if __has_include("geometry/graph_ops_dag.h")
-    #include "geometry/graph_ops_dag.h"
-    #define HAS_OP_SUITE_DAG
-  #endif
-  #if __has_include("geometry/graph_ops_neuralnetwork.h")
-    #include "geometry/graph_ops_neuralnetwork.h"
-    #define HAS_OP_SUITE_NEURALNETWORK
-  #endif
-  #if __has_include("geometry/graph_ops_linkedlist.h")
-    #include "geometry/graph_ops_linkedlist.h"
-    #define HAS_OP_SUITE_LINKEDLIST
-  #endif
-  #if __has_include("geometry/graph_ops_list.h")
-    #include "geometry/graph_ops_list.h"
-    #define HAS_OP_SUITE_LIST
-  #endif
-  #if __has_include("geometry/graph_ops_parallel_list.h")
-    #include "geometry/graph_ops_parallel_list.h"
-    #define HAS_OP_SUITE_PARALLEL_LIST
-  #endif
-  #if __has_include("geometry/graph_ops_dict.h")
-    #include "geometry/graph_ops_dict.h"
-    #define HAS_OP_SUITE_DICT
-  #endif
-  #if __has_include("geometry/graph_ops_set.h")
-    #include "geometry/graph_ops_set.h"
-    #define HAS_OP_SUITE_SET
-  #endif
-  #if __has_include("geometry/graph_ops_map.h")
-    #include "geometry/graph_ops_map.h"
-    #define HAS_OP_SUITE_MAP
-  #endif
-  #if __has_include("geometry/graph_ops_heap.h")
-    #include "geometry/graph_ops_heap.h"
-    #define HAS_OP_SUITE_HEAP
-  #endif
-  #if __has_include("geometry/graph_ops_mailbox.h")
-    #include "geometry/graph_ops_mailbox.h"
-    #define HAS_OP_SUITE_MAILBOX
-  #endif
-  #if __has_include("geometry/graph_ops_token.h")
-    #include "geometry/graph_ops_token.h"
-    #define HAS_OP_SUITE_TOKEN
-  #endif
-  #if __has_include("geometry/graph_ops_object_set.h")
-    #include "geometry/graph_ops_object_set.h"
-    #define HAS_OP_SUITE_OBJECT_SET
-  #endif
-  #if __has_include("geometry/graph_ops_stack.h")
-    #include "geometry/graph_ops_stack.h"
-    #define HAS_OP_SUITE_STACK
-  #endif
-  #if __has_include("geometry/graph_ops_stencil_set.h")
-    #include "geometry/graph_ops_stencil_set.h"
-    #define HAS_OP_SUITE_STENCIL_SET
-  #endif
-  #if __has_include("geometry/graph_ops_emergence.h")
-    #include "geometry/graph_ops_emergence.h"
-    #define HAS_OP_SUITE_EMERGENCE
-  #endif
-  /* Feature-type suite headers */
-  #if __has_include("geometry/graph_ops_vector_int.h")
-    #include "geometry/graph_ops_vector_int.h"
-    #define HAS_OP_SUITE_VECTOR_INT
-  #endif
-  #if __has_include("geometry/graph_ops_vector_float.h")
-    #include "geometry/graph_ops_vector_float.h"
-    #define HAS_OP_SUITE_VECTOR_FLOAT
-  #endif
-  #if __has_include("geometry/graph_ops_vector_double.h")
-    #include "geometry/graph_ops_vector_double.h"
-    #define HAS_OP_SUITE_VECTOR_DOUBLE
-  #endif
-  #if __has_include("geometry/graph_ops_vector_string.h")
-    #include "geometry/graph_ops_vector_string.h"
-    #define HAS_OP_SUITE_VECTOR_STRING
-  #endif
-  #if __has_include("geometry/graph_ops_vector_boolean.h")
-    #include "geometry/graph_ops_vector_boolean.h"
-    #define HAS_OP_SUITE_VECTOR_BOOLEAN
-  #endif
-  #if __has_include("geometry/graph_ops_vector_pointer.h")
-    #include "geometry/graph_ops_vector_pointer.h"
-    #define HAS_OP_SUITE_VECTOR_POINTER
-  #endif
-  #if __has_include("geometry/graph_ops_tensor_int.h")
-    #include "geometry/graph_ops_tensor_int.h"
-    #define HAS_OP_SUITE_TENSOR_INT
-  #endif
-  #if __has_include("geometry/graph_ops_tensor_float.h")
-    #include "geometry/graph_ops_tensor_float.h"
-    #define HAS_OP_SUITE_TENSOR_FLOAT
-  #endif
-  #if __has_include("geometry/graph_ops_tensor_double.h")
-    #include "geometry/graph_ops_tensor_double.h"
-    #define HAS_OP_SUITE_TENSOR_DOUBLE
-  #endif
-  #if __has_include("geometry/graph_ops_tensor_string.h")
-    #include "geometry/graph_ops_tensor_string.h"
-    #define HAS_OP_SUITE_TENSOR_STRING
-  #endif
-  #if __has_include("geometry/graph_ops_tensor_boolean.h")
-    #include "geometry/graph_ops_tensor_boolean.h"
-    #define HAS_OP_SUITE_TENSOR_BOOLEAN
-  #endif
-  #if __has_include("geometry/graph_ops_tensor_pointer.h")
-    #include "geometry/graph_ops_tensor_pointer.h"
-    #define HAS_OP_SUITE_TENSOR_POINTER
-  #endif
-  #if __has_include("geometry/graph_ops_tensor_vector_int.h")
-    #include "geometry/graph_ops_tensor_vector_int.h"
-    #define HAS_OP_SUITE_TENSOR_VECTOR_INT
-  #endif
-  #if __has_include("geometry/graph_ops_tensor_vector_float.h")
-    #include "geometry/graph_ops_tensor_vector_float.h"
-    #define HAS_OP_SUITE_TENSOR_VECTOR_FLOAT
-  #endif
-  #if __has_include("geometry/graph_ops_tensor_vector_double.h")
-    #include "geometry/graph_ops_tensor_vector_double.h"
-    #define HAS_OP_SUITE_TENSOR_VECTOR_DOUBLE
-  #endif
-  #if __has_include("geometry/graph_ops_tensor_vector_string.h")
-    #include "geometry/graph_ops_tensor_vector_string.h"
-    #define HAS_OP_SUITE_TENSOR_VECTOR_STRING
-  #endif
-  #if __has_include("geometry/graph_ops_tensor_vector_boolean.h")
-    #include "geometry/graph_ops_tensor_vector_boolean.h"
-    #define HAS_OP_SUITE_TENSOR_VECTOR_BOOLEAN
-  #endif
-  #if __has_include("geometry/graph_ops_node_feature.h")
-    #include "geometry/graph_ops_node_feature.h"
-    #define HAS_OP_SUITE_NODE_FEATURE
-  #endif
-  #if __has_include("geometry/graph_ops_edge.h")
-    #include "geometry/graph_ops_edge.h"
-    #define HAS_OP_SUITE_EDGE
-  #endif
-  #if __has_include("geometry/graph_ops_stencil.h")
-    #include "geometry/graph_ops_stencil.h"
-    #define HAS_OP_SUITE_STENCIL
-  #endif
-  #if __has_include("geometry/graph_ops_geneology.h")
-    #include "geometry/graph_ops_geneology.h"
-    #define HAS_OP_SUITE_GENEALOGY_OP
-  #endif
-  #if __has_include("geometry/graph_ops_emergence.h")
-    /* already included above */
-  #endif
-  /* Additional detections for utils primitives e.g. linkedlist, dict, set, etc. */
-#endif /* __has_include */
+/* Include operation suites for all known node feature types. */
+#include "geometry/graph_ops_int.h"
+#include "geometry/graph_ops_float.h"
+#include "geometry/graph_ops_double.h"
+#include "geometry/graph_ops_string.h"
+#include "geometry/graph_ops_boolean.h"
+#include "geometry/graph_ops_pointer.h"
+#include "geometry/graph_ops_vector_int.h"
+#include "geometry/graph_ops_vector_float.h"
+#include "geometry/graph_ops_vector_double.h"
+#include "geometry/graph_ops_vector_string.h"
+#include "geometry/graph_ops_vector_boolean.h"
+#include "geometry/graph_ops_vector_pointer.h"
+#include "geometry/graph_ops_tensor_int.h"
+#include "geometry/graph_ops_tensor_float.h"
+#include "geometry/graph_ops_tensor_double.h"
+#include "geometry/graph_ops_tensor_string.h"
+#include "geometry/graph_ops_tensor_boolean.h"
+#include "geometry/graph_ops_tensor_pointer.h"
+#include "geometry/graph_ops_tensor_vector_int.h"
+#include "geometry/graph_ops_tensor_vector_float.h"
+#include "geometry/graph_ops_tensor_vector_double.h"
+#include "geometry/graph_ops_tensor_vector_string.h"
+#include "geometry/graph_ops_tensor_vector_boolean.h"
+#include "geometry/graph_ops_tensor_vector_pointer.h"
+#include "geometry/graph_ops_node.h"
+#include "geometry/graph_ops_edge.h"
+#include "geometry/graph_ops_stencil.h"
+#include "geometry/graph_ops_genealogy.h"
+#include "geometry/graph_ops_emergence.h"
+#include "geometry/graph_ops_linked_list.h"
+#include "geometry/graph_ops_dictionary.h"
+#include "geometry/graph_ops_set.h"
+#include "geometry/graph_ops_map.h"
+#include "geometry/graph_ops_parallel_list.h"
+#include "geometry/graph_ops_list.h"
+#include "geometry/graph_ops_pointer_token.h"
+#include "geometry/graph_ops_guardian.h"
+#include "geometry/graph_ops_token.h"
+#include "geometry/graph_ops_object_set.h"
+#include "geometry/graph_ops_memory_token.h"
+#include "geometry/graph_ops_token_lock.h"
+#include "geometry/graph_ops_memory_map.h"
+#include "geometry/graph_ops_message.h"
+#include "geometry/graph_ops_custom.h"
 
 /* Array of pointers to each suite; defined in graph_ops_handler.c */
 extern const OperationSuite* const OperationSuites[];
@@ -180,7 +60,7 @@ extern const OperationSuite* const OperationSuites[];
  * Retrieve the OperationSuite for the given type.
  * Returns NULL if the suite is not available or type is invalid.
  */
-const OperationSuite* get_operation_suite(OperationSuiteType type);
+const OperationSuite* get_operation_suite(NodeFeatureType type);
 
 #ifdef __cplusplus
 }

--- a/include/geometry/graph_ops_int.h
+++ b/include/geometry/graph_ops_int.h
@@ -1,0 +1,9 @@
+#ifndef GEOMETRY_GRAPH_OPS_INT_H
+#define GEOMETRY_GRAPH_OPS_INT_H
+
+#include "geometry/graph_ops.h"
+
+/* Stub operation suite for int */
+extern const OperationSuite graph_ops_int;
+
+#endif /* GEOMETRY_GRAPH_OPS_INT_H */

--- a/include/geometry/graph_ops_linked_list.h
+++ b/include/geometry/graph_ops_linked_list.h
@@ -1,0 +1,9 @@
+#ifndef GEOMETRY_GRAPH_OPS_LINKED_LIST_H
+#define GEOMETRY_GRAPH_OPS_LINKED_LIST_H
+
+#include "geometry/graph_ops.h"
+
+/* Stub operation suite for linked_list */
+extern const OperationSuite graph_ops_linked_list;
+
+#endif /* GEOMETRY_GRAPH_OPS_LINKED_LIST_H */

--- a/include/geometry/graph_ops_list.h
+++ b/include/geometry/graph_ops_list.h
@@ -1,0 +1,9 @@
+#ifndef GEOMETRY_GRAPH_OPS_LIST_H
+#define GEOMETRY_GRAPH_OPS_LIST_H
+
+#include "geometry/graph_ops.h"
+
+/* Stub operation suite for list */
+extern const OperationSuite graph_ops_list;
+
+#endif /* GEOMETRY_GRAPH_OPS_LIST_H */

--- a/include/geometry/graph_ops_map.h
+++ b/include/geometry/graph_ops_map.h
@@ -1,0 +1,9 @@
+#ifndef GEOMETRY_GRAPH_OPS_MAP_H
+#define GEOMETRY_GRAPH_OPS_MAP_H
+
+#include "geometry/graph_ops.h"
+
+/* Stub operation suite for map */
+extern const OperationSuite graph_ops_map;
+
+#endif /* GEOMETRY_GRAPH_OPS_MAP_H */

--- a/include/geometry/graph_ops_memory_map.h
+++ b/include/geometry/graph_ops_memory_map.h
@@ -1,0 +1,9 @@
+#ifndef GEOMETRY_GRAPH_OPS_MEMORY_MAP_H
+#define GEOMETRY_GRAPH_OPS_MEMORY_MAP_H
+
+#include "geometry/graph_ops.h"
+
+/* Stub operation suite for memory_map */
+extern const OperationSuite graph_ops_memory_map;
+
+#endif /* GEOMETRY_GRAPH_OPS_MEMORY_MAP_H */

--- a/include/geometry/graph_ops_memory_token.h
+++ b/include/geometry/graph_ops_memory_token.h
@@ -1,0 +1,9 @@
+#ifndef GEOMETRY_GRAPH_OPS_MEMORY_TOKEN_H
+#define GEOMETRY_GRAPH_OPS_MEMORY_TOKEN_H
+
+#include "geometry/graph_ops.h"
+
+/* Stub operation suite for memory_token */
+extern const OperationSuite graph_ops_memory_token;
+
+#endif /* GEOMETRY_GRAPH_OPS_MEMORY_TOKEN_H */

--- a/include/geometry/graph_ops_message.h
+++ b/include/geometry/graph_ops_message.h
@@ -1,0 +1,9 @@
+#ifndef GEOMETRY_GRAPH_OPS_MESSAGE_H
+#define GEOMETRY_GRAPH_OPS_MESSAGE_H
+
+#include "geometry/graph_ops.h"
+
+/* Stub operation suite for message */
+extern const OperationSuite graph_ops_message;
+
+#endif /* GEOMETRY_GRAPH_OPS_MESSAGE_H */

--- a/include/geometry/graph_ops_node.h
+++ b/include/geometry/graph_ops_node.h
@@ -1,0 +1,9 @@
+#ifndef GEOMETRY_GRAPH_OPS_NODE_H
+#define GEOMETRY_GRAPH_OPS_NODE_H
+
+#include "geometry/graph_ops.h"
+
+/* Stub operation suite for node */
+extern const OperationSuite graph_ops_node;
+
+#endif /* GEOMETRY_GRAPH_OPS_NODE_H */

--- a/include/geometry/graph_ops_object_set.h
+++ b/include/geometry/graph_ops_object_set.h
@@ -1,0 +1,9 @@
+#ifndef GEOMETRY_GRAPH_OPS_OBJECT_SET_H
+#define GEOMETRY_GRAPH_OPS_OBJECT_SET_H
+
+#include "geometry/graph_ops.h"
+
+/* Stub operation suite for object_set */
+extern const OperationSuite graph_ops_object_set;
+
+#endif /* GEOMETRY_GRAPH_OPS_OBJECT_SET_H */

--- a/include/geometry/graph_ops_parallel_list.h
+++ b/include/geometry/graph_ops_parallel_list.h
@@ -1,0 +1,9 @@
+#ifndef GEOMETRY_GRAPH_OPS_PARALLEL_LIST_H
+#define GEOMETRY_GRAPH_OPS_PARALLEL_LIST_H
+
+#include "geometry/graph_ops.h"
+
+/* Stub operation suite for parallel_list */
+extern const OperationSuite graph_ops_parallel_list;
+
+#endif /* GEOMETRY_GRAPH_OPS_PARALLEL_LIST_H */

--- a/include/geometry/graph_ops_pointer.h
+++ b/include/geometry/graph_ops_pointer.h
@@ -1,0 +1,9 @@
+#ifndef GEOMETRY_GRAPH_OPS_POINTER_H
+#define GEOMETRY_GRAPH_OPS_POINTER_H
+
+#include "geometry/graph_ops.h"
+
+/* Stub operation suite for pointer */
+extern const OperationSuite graph_ops_pointer;
+
+#endif /* GEOMETRY_GRAPH_OPS_POINTER_H */

--- a/include/geometry/graph_ops_pointer_token.h
+++ b/include/geometry/graph_ops_pointer_token.h
@@ -1,0 +1,9 @@
+#ifndef GEOMETRY_GRAPH_OPS_POINTER_TOKEN_H
+#define GEOMETRY_GRAPH_OPS_POINTER_TOKEN_H
+
+#include "geometry/graph_ops.h"
+
+/* Stub operation suite for pointer_token */
+extern const OperationSuite graph_ops_pointer_token;
+
+#endif /* GEOMETRY_GRAPH_OPS_POINTER_TOKEN_H */

--- a/include/geometry/graph_ops_set.h
+++ b/include/geometry/graph_ops_set.h
@@ -1,0 +1,9 @@
+#ifndef GEOMETRY_GRAPH_OPS_SET_H
+#define GEOMETRY_GRAPH_OPS_SET_H
+
+#include "geometry/graph_ops.h"
+
+/* Stub operation suite for set */
+extern const OperationSuite graph_ops_set;
+
+#endif /* GEOMETRY_GRAPH_OPS_SET_H */

--- a/include/geometry/graph_ops_stencil.h
+++ b/include/geometry/graph_ops_stencil.h
@@ -1,0 +1,9 @@
+#ifndef GEOMETRY_GRAPH_OPS_STENCIL_H
+#define GEOMETRY_GRAPH_OPS_STENCIL_H
+
+#include "geometry/graph_ops.h"
+
+/* Stub operation suite for stencil */
+extern const OperationSuite graph_ops_stencil;
+
+#endif /* GEOMETRY_GRAPH_OPS_STENCIL_H */

--- a/include/geometry/graph_ops_string.h
+++ b/include/geometry/graph_ops_string.h
@@ -1,0 +1,9 @@
+#ifndef GEOMETRY_GRAPH_OPS_STRING_H
+#define GEOMETRY_GRAPH_OPS_STRING_H
+
+#include "geometry/graph_ops.h"
+
+/* Stub operation suite for string */
+extern const OperationSuite graph_ops_string;
+
+#endif /* GEOMETRY_GRAPH_OPS_STRING_H */

--- a/include/geometry/graph_ops_tensor_boolean.h
+++ b/include/geometry/graph_ops_tensor_boolean.h
@@ -1,0 +1,9 @@
+#ifndef GEOMETRY_GRAPH_OPS_TENSOR_BOOLEAN_H
+#define GEOMETRY_GRAPH_OPS_TENSOR_BOOLEAN_H
+
+#include "geometry/graph_ops.h"
+
+/* Stub operation suite for tensor_boolean */
+extern const OperationSuite graph_ops_tensor_boolean;
+
+#endif /* GEOMETRY_GRAPH_OPS_TENSOR_BOOLEAN_H */

--- a/include/geometry/graph_ops_tensor_double.h
+++ b/include/geometry/graph_ops_tensor_double.h
@@ -1,0 +1,9 @@
+#ifndef GEOMETRY_GRAPH_OPS_TENSOR_DOUBLE_H
+#define GEOMETRY_GRAPH_OPS_TENSOR_DOUBLE_H
+
+#include "geometry/graph_ops.h"
+
+/* Stub operation suite for tensor_double */
+extern const OperationSuite graph_ops_tensor_double;
+
+#endif /* GEOMETRY_GRAPH_OPS_TENSOR_DOUBLE_H */

--- a/include/geometry/graph_ops_tensor_float.h
+++ b/include/geometry/graph_ops_tensor_float.h
@@ -1,0 +1,9 @@
+#ifndef GEOMETRY_GRAPH_OPS_TENSOR_FLOAT_H
+#define GEOMETRY_GRAPH_OPS_TENSOR_FLOAT_H
+
+#include "geometry/graph_ops.h"
+
+/* Stub operation suite for tensor_float */
+extern const OperationSuite graph_ops_tensor_float;
+
+#endif /* GEOMETRY_GRAPH_OPS_TENSOR_FLOAT_H */

--- a/include/geometry/graph_ops_tensor_int.h
+++ b/include/geometry/graph_ops_tensor_int.h
@@ -1,0 +1,9 @@
+#ifndef GEOMETRY_GRAPH_OPS_TENSOR_INT_H
+#define GEOMETRY_GRAPH_OPS_TENSOR_INT_H
+
+#include "geometry/graph_ops.h"
+
+/* Stub operation suite for tensor_int */
+extern const OperationSuite graph_ops_tensor_int;
+
+#endif /* GEOMETRY_GRAPH_OPS_TENSOR_INT_H */

--- a/include/geometry/graph_ops_tensor_pointer.h
+++ b/include/geometry/graph_ops_tensor_pointer.h
@@ -1,0 +1,9 @@
+#ifndef GEOMETRY_GRAPH_OPS_TENSOR_POINTER_H
+#define GEOMETRY_GRAPH_OPS_TENSOR_POINTER_H
+
+#include "geometry/graph_ops.h"
+
+/* Stub operation suite for tensor_pointer */
+extern const OperationSuite graph_ops_tensor_pointer;
+
+#endif /* GEOMETRY_GRAPH_OPS_TENSOR_POINTER_H */

--- a/include/geometry/graph_ops_tensor_string.h
+++ b/include/geometry/graph_ops_tensor_string.h
@@ -1,0 +1,9 @@
+#ifndef GEOMETRY_GRAPH_OPS_TENSOR_STRING_H
+#define GEOMETRY_GRAPH_OPS_TENSOR_STRING_H
+
+#include "geometry/graph_ops.h"
+
+/* Stub operation suite for tensor_string */
+extern const OperationSuite graph_ops_tensor_string;
+
+#endif /* GEOMETRY_GRAPH_OPS_TENSOR_STRING_H */

--- a/include/geometry/graph_ops_tensor_vector_boolean.h
+++ b/include/geometry/graph_ops_tensor_vector_boolean.h
@@ -1,0 +1,9 @@
+#ifndef GEOMETRY_GRAPH_OPS_TENSOR_VECTOR_BOOLEAN_H
+#define GEOMETRY_GRAPH_OPS_TENSOR_VECTOR_BOOLEAN_H
+
+#include "geometry/graph_ops.h"
+
+/* Stub operation suite for tensor_vector_boolean */
+extern const OperationSuite graph_ops_tensor_vector_boolean;
+
+#endif /* GEOMETRY_GRAPH_OPS_TENSOR_VECTOR_BOOLEAN_H */

--- a/include/geometry/graph_ops_tensor_vector_double.h
+++ b/include/geometry/graph_ops_tensor_vector_double.h
@@ -1,0 +1,9 @@
+#ifndef GEOMETRY_GRAPH_OPS_TENSOR_VECTOR_DOUBLE_H
+#define GEOMETRY_GRAPH_OPS_TENSOR_VECTOR_DOUBLE_H
+
+#include "geometry/graph_ops.h"
+
+/* Stub operation suite for tensor_vector_double */
+extern const OperationSuite graph_ops_tensor_vector_double;
+
+#endif /* GEOMETRY_GRAPH_OPS_TENSOR_VECTOR_DOUBLE_H */

--- a/include/geometry/graph_ops_tensor_vector_float.h
+++ b/include/geometry/graph_ops_tensor_vector_float.h
@@ -1,0 +1,9 @@
+#ifndef GEOMETRY_GRAPH_OPS_TENSOR_VECTOR_FLOAT_H
+#define GEOMETRY_GRAPH_OPS_TENSOR_VECTOR_FLOAT_H
+
+#include "geometry/graph_ops.h"
+
+/* Stub operation suite for tensor_vector_float */
+extern const OperationSuite graph_ops_tensor_vector_float;
+
+#endif /* GEOMETRY_GRAPH_OPS_TENSOR_VECTOR_FLOAT_H */

--- a/include/geometry/graph_ops_tensor_vector_int.h
+++ b/include/geometry/graph_ops_tensor_vector_int.h
@@ -1,0 +1,9 @@
+#ifndef GEOMETRY_GRAPH_OPS_TENSOR_VECTOR_INT_H
+#define GEOMETRY_GRAPH_OPS_TENSOR_VECTOR_INT_H
+
+#include "geometry/graph_ops.h"
+
+/* Stub operation suite for tensor_vector_int */
+extern const OperationSuite graph_ops_tensor_vector_int;
+
+#endif /* GEOMETRY_GRAPH_OPS_TENSOR_VECTOR_INT_H */

--- a/include/geometry/graph_ops_tensor_vector_pointer.h
+++ b/include/geometry/graph_ops_tensor_vector_pointer.h
@@ -1,0 +1,9 @@
+#ifndef GEOMETRY_GRAPH_OPS_TENSOR_VECTOR_POINTER_H
+#define GEOMETRY_GRAPH_OPS_TENSOR_VECTOR_POINTER_H
+
+#include "geometry/graph_ops.h"
+
+/* Stub operation suite for tensor_vector_pointer */
+extern const OperationSuite graph_ops_tensor_vector_pointer;
+
+#endif /* GEOMETRY_GRAPH_OPS_TENSOR_VECTOR_POINTER_H */

--- a/include/geometry/graph_ops_tensor_vector_string.h
+++ b/include/geometry/graph_ops_tensor_vector_string.h
@@ -1,0 +1,9 @@
+#ifndef GEOMETRY_GRAPH_OPS_TENSOR_VECTOR_STRING_H
+#define GEOMETRY_GRAPH_OPS_TENSOR_VECTOR_STRING_H
+
+#include "geometry/graph_ops.h"
+
+/* Stub operation suite for tensor_vector_string */
+extern const OperationSuite graph_ops_tensor_vector_string;
+
+#endif /* GEOMETRY_GRAPH_OPS_TENSOR_VECTOR_STRING_H */

--- a/include/geometry/graph_ops_token.h
+++ b/include/geometry/graph_ops_token.h
@@ -1,0 +1,9 @@
+#ifndef GEOMETRY_GRAPH_OPS_TOKEN_H
+#define GEOMETRY_GRAPH_OPS_TOKEN_H
+
+#include "geometry/graph_ops.h"
+
+/* Stub operation suite for token */
+extern const OperationSuite graph_ops_token;
+
+#endif /* GEOMETRY_GRAPH_OPS_TOKEN_H */

--- a/include/geometry/graph_ops_token_lock.h
+++ b/include/geometry/graph_ops_token_lock.h
@@ -1,0 +1,9 @@
+#ifndef GEOMETRY_GRAPH_OPS_TOKEN_LOCK_H
+#define GEOMETRY_GRAPH_OPS_TOKEN_LOCK_H
+
+#include "geometry/graph_ops.h"
+
+/* Stub operation suite for token_lock */
+extern const OperationSuite graph_ops_token_lock;
+
+#endif /* GEOMETRY_GRAPH_OPS_TOKEN_LOCK_H */

--- a/include/geometry/graph_ops_vector_boolean.h
+++ b/include/geometry/graph_ops_vector_boolean.h
@@ -1,0 +1,9 @@
+#ifndef GEOMETRY_GRAPH_OPS_VECTOR_BOOLEAN_H
+#define GEOMETRY_GRAPH_OPS_VECTOR_BOOLEAN_H
+
+#include "geometry/graph_ops.h"
+
+/* Stub operation suite for vector_boolean */
+extern const OperationSuite graph_ops_vector_boolean;
+
+#endif /* GEOMETRY_GRAPH_OPS_VECTOR_BOOLEAN_H */

--- a/include/geometry/graph_ops_vector_double.h
+++ b/include/geometry/graph_ops_vector_double.h
@@ -1,0 +1,9 @@
+#ifndef GEOMETRY_GRAPH_OPS_VECTOR_DOUBLE_H
+#define GEOMETRY_GRAPH_OPS_VECTOR_DOUBLE_H
+
+#include "geometry/graph_ops.h"
+
+/* Stub operation suite for vector_double */
+extern const OperationSuite graph_ops_vector_double;
+
+#endif /* GEOMETRY_GRAPH_OPS_VECTOR_DOUBLE_H */

--- a/include/geometry/graph_ops_vector_float.h
+++ b/include/geometry/graph_ops_vector_float.h
@@ -1,0 +1,9 @@
+#ifndef GEOMETRY_GRAPH_OPS_VECTOR_FLOAT_H
+#define GEOMETRY_GRAPH_OPS_VECTOR_FLOAT_H
+
+#include "geometry/graph_ops.h"
+
+/* Stub operation suite for vector_float */
+extern const OperationSuite graph_ops_vector_float;
+
+#endif /* GEOMETRY_GRAPH_OPS_VECTOR_FLOAT_H */

--- a/include/geometry/graph_ops_vector_int.h
+++ b/include/geometry/graph_ops_vector_int.h
@@ -1,0 +1,9 @@
+#ifndef GEOMETRY_GRAPH_OPS_VECTOR_INT_H
+#define GEOMETRY_GRAPH_OPS_VECTOR_INT_H
+
+#include "geometry/graph_ops.h"
+
+/* Stub operation suite for vector_int */
+extern const OperationSuite graph_ops_vector_int;
+
+#endif /* GEOMETRY_GRAPH_OPS_VECTOR_INT_H */

--- a/include/geometry/graph_ops_vector_pointer.h
+++ b/include/geometry/graph_ops_vector_pointer.h
@@ -1,0 +1,9 @@
+#ifndef GEOMETRY_GRAPH_OPS_VECTOR_POINTER_H
+#define GEOMETRY_GRAPH_OPS_VECTOR_POINTER_H
+
+#include "geometry/graph_ops.h"
+
+/* Stub operation suite for vector_pointer */
+extern const OperationSuite graph_ops_vector_pointer;
+
+#endif /* GEOMETRY_GRAPH_OPS_VECTOR_POINTER_H */

--- a/include/geometry/graph_ops_vector_string.h
+++ b/include/geometry/graph_ops_vector_string.h
@@ -1,0 +1,9 @@
+#ifndef GEOMETRY_GRAPH_OPS_VECTOR_STRING_H
+#define GEOMETRY_GRAPH_OPS_VECTOR_STRING_H
+
+#include "geometry/graph_ops.h"
+
+/* Stub operation suite for vector_string */
+extern const OperationSuite graph_ops_vector_string;
+
+#endif /* GEOMETRY_GRAPH_OPS_VECTOR_STRING_H */

--- a/src/geometry/graph_ops_boolean.c
+++ b/src/geometry/graph_ops_boolean.c
@@ -1,0 +1,4 @@
+#include "geometry/graph_ops_boolean.h"
+
+/* Empty stub suite */
+const OperationSuite graph_ops_boolean = {0};

--- a/src/geometry/graph_ops_custom.c
+++ b/src/geometry/graph_ops_custom.c
@@ -1,0 +1,4 @@
+#include "geometry/graph_ops_custom.h"
+
+/* Empty stub suite */
+const OperationSuite graph_ops_custom = {0};

--- a/src/geometry/graph_ops_dictionary.c
+++ b/src/geometry/graph_ops_dictionary.c
@@ -1,0 +1,4 @@
+#include "geometry/graph_ops_dictionary.h"
+
+/* Empty stub suite */
+const OperationSuite graph_ops_dictionary = {0};

--- a/src/geometry/graph_ops_double.c
+++ b/src/geometry/graph_ops_double.c
@@ -1,0 +1,4 @@
+#include "geometry/graph_ops_double.h"
+
+/* Empty stub suite */
+const OperationSuite graph_ops_double = {0};

--- a/src/geometry/graph_ops_edge.c
+++ b/src/geometry/graph_ops_edge.c
@@ -1,0 +1,4 @@
+#include "geometry/graph_ops_edge.h"
+
+/* Empty stub suite */
+const OperationSuite graph_ops_edge = {0};

--- a/src/geometry/graph_ops_emergence.c
+++ b/src/geometry/graph_ops_emergence.c
@@ -1,0 +1,4 @@
+#include "geometry/graph_ops_emergence.h"
+
+/* Empty stub suite */
+const OperationSuite graph_ops_emergence = {0};

--- a/src/geometry/graph_ops_float.c
+++ b/src/geometry/graph_ops_float.c
@@ -1,0 +1,4 @@
+#include "geometry/graph_ops_float.h"
+
+/* Empty stub suite */
+const OperationSuite graph_ops_float = {0};

--- a/src/geometry/graph_ops_genealogy.c
+++ b/src/geometry/graph_ops_genealogy.c
@@ -1,0 +1,4 @@
+#include "geometry/graph_ops_genealogy.h"
+
+/* Empty stub suite */
+const OperationSuite graph_ops_genealogy = {0};

--- a/src/geometry/graph_ops_guardian.c
+++ b/src/geometry/graph_ops_guardian.c
@@ -1,0 +1,4 @@
+#include "geometry/graph_ops_guardian.h"
+
+/* Empty stub suite */
+const OperationSuite graph_ops_guardian = {0};

--- a/src/geometry/graph_ops_handler.c
+++ b/src/geometry/graph_ops_handler.c
@@ -1,0 +1,57 @@
+#include "geometry/graph_ops_handler.h"
+
+/* OperationSuite table mapping each NodeFeatureType to its implementation.
+   All suites are currently stubs defined in the corresponding headers. */
+const OperationSuite* const OperationSuites[NODE_FEATURE_TYPE_COUNT] = {
+    &graph_ops_int,                /* NODE_FEATURE_TYPE_INT */
+    &graph_ops_float,              /* NODE_FEATURE_TYPE_FLOAT */
+    &graph_ops_double,             /* NODE_FEATURE_TYPE_DOUBLE */
+    &graph_ops_string,             /* NODE_FEATURE_TYPE_STRING */
+    &graph_ops_boolean,            /* NODE_FEATURE_TYPE_BOOLEAN */
+    &graph_ops_pointer,            /* NODE_FEATURE_TYPE_POINTER */
+    &graph_ops_vector_int,         /* NODE_FEATURE_TYPE_VECTOR_INT */
+    &graph_ops_vector_float,       /* NODE_FEATURE_TYPE_VECTOR_FLOAT */
+    &graph_ops_vector_double,      /* NODE_FEATURE_TYPE_VECTOR_DOUBLE */
+    &graph_ops_vector_string,      /* NODE_FEATURE_TYPE_VECTOR_STRING */
+    &graph_ops_vector_boolean,     /* NODE_FEATURE_TYPE_VECTOR_BOOLEAN */
+    &graph_ops_vector_pointer,     /* NODE_FEATURE_TYPE_VECTOR_POINTER */
+    &graph_ops_tensor_int,         /* NODE_FEATURE_TYPE_TENSOR_INT */
+    &graph_ops_tensor_float,       /* NODE_FEATURE_TYPE_TENSOR_FLOAT */
+    &graph_ops_tensor_double,      /* NODE_FEATURE_TYPE_TENSOR_DOUBLE */
+    &graph_ops_tensor_string,      /* NODE_FEATURE_TYPE_TENSOR_STRING */
+    &graph_ops_tensor_boolean,     /* NODE_FEATURE_TYPE_TENSOR_BOOLEAN */
+    &graph_ops_tensor_pointer,     /* NODE_FEATURE_TYPE_TENSOR_POINTER */
+    &graph_ops_tensor_vector_int,  /* NODE_FEATURE_TYPE_TENSOR_VECTOR_INT */
+    &graph_ops_tensor_vector_float,/* NODE_FEATURE_TYPE_TENSOR_VECTOR_FLOAT */
+    &graph_ops_tensor_vector_double,/* NODE_FEATURE_TYPE_TENSOR_VECTOR_DOUBLE */
+    &graph_ops_tensor_vector_string,/* NODE_FEATURE_TYPE_TENSOR_VECTOR_STRING */
+    &graph_ops_tensor_vector_boolean,/* NODE_FEATURE_TYPE_TENSOR_VECTOR_BOOLEAN */
+    &graph_ops_tensor_vector_pointer,/* NODE_FEATURE_TYPE_TENSOR_VECTOR_POINTER */
+    &graph_ops_node,               /* NODE_FEATURE_TYPE_NODE */
+    &graph_ops_edge,               /* NODE_FEATURE_TYPE_EDGE */
+    &graph_ops_stencil,            /* NODE_FEATURE_TYPE_STENCIL */
+    &graph_ops_genealogy,          /* NODE_FEATURE_TYPE_GENEALOGY */
+    &graph_ops_emergence,          /* NODE_FEATURE_TYPE_EMERGENCE */
+    &graph_ops_linked_list,        /* NODE_FEATURE_TYPE_LINKED_LIST */
+    &graph_ops_dictionary,         /* NODE_FEATURE_TYPE_DICTIONARY */
+    &graph_ops_set,                /* NODE_FEATURE_TYPE_SET */
+    &graph_ops_map,                /* NODE_FEATURE_TYPE_MAP */
+    &graph_ops_parallel_list,      /* NODE_FEATURE_TYPE_PARALLEL_LIST */
+    &graph_ops_list,               /* NODE_FEATURE_TYPE_LIST */
+    &graph_ops_pointer_token,      /* NODE_FEATURE_TYPE_POINTER_TOKEN */
+    &graph_ops_guardian,           /* NODE_FEATURE_TYPE_GUARDIAN */
+    &graph_ops_token,              /* NODE_FEATURE_TYPE_TOKEN */
+    &graph_ops_object_set,         /* NODE_FEATURE_TYPE_OBJECT_SET */
+    &graph_ops_memory_token,       /* NODE_FEATURE_TYPE_MEMORY_TOKEN */
+    &graph_ops_token_lock,         /* NODE_FEATURE_TYPE_TOKEN_LOCK */
+    &graph_ops_memory_map,         /* NODE_FEATURE_TYPE_MEMORY_MAP */
+    &graph_ops_message,            /* NODE_FEATURE_TYPE_MESSAGE */
+    &graph_ops_custom              /* NODE_FEATURE_TYPE_CUSTOM */
+};
+
+const OperationSuite* get_operation_suite(NodeFeatureType type) {
+    if (type < 0 || type >= NODE_FEATURE_TYPE_COUNT) {
+        return NULL;
+    }
+    return OperationSuites[type];
+}

--- a/src/geometry/graph_ops_int.c
+++ b/src/geometry/graph_ops_int.c
@@ -1,0 +1,4 @@
+#include "geometry/graph_ops_int.h"
+
+/* Empty stub suite */
+const OperationSuite graph_ops_int = {0};

--- a/src/geometry/graph_ops_linked_list.c
+++ b/src/geometry/graph_ops_linked_list.c
@@ -1,0 +1,4 @@
+#include "geometry/graph_ops_linked_list.h"
+
+/* Empty stub suite */
+const OperationSuite graph_ops_linked_list = {0};

--- a/src/geometry/graph_ops_list.c
+++ b/src/geometry/graph_ops_list.c
@@ -1,0 +1,4 @@
+#include "geometry/graph_ops_list.h"
+
+/* Empty stub suite */
+const OperationSuite graph_ops_list = {0};

--- a/src/geometry/graph_ops_map.c
+++ b/src/geometry/graph_ops_map.c
@@ -1,0 +1,4 @@
+#include "geometry/graph_ops_map.h"
+
+/* Empty stub suite */
+const OperationSuite graph_ops_map = {0};

--- a/src/geometry/graph_ops_memory_map.c
+++ b/src/geometry/graph_ops_memory_map.c
@@ -1,0 +1,4 @@
+#include "geometry/graph_ops_memory_map.h"
+
+/* Empty stub suite */
+const OperationSuite graph_ops_memory_map = {0};

--- a/src/geometry/graph_ops_memory_token.c
+++ b/src/geometry/graph_ops_memory_token.c
@@ -1,0 +1,4 @@
+#include "geometry/graph_ops_memory_token.h"
+
+/* Empty stub suite */
+const OperationSuite graph_ops_memory_token = {0};

--- a/src/geometry/graph_ops_message.c
+++ b/src/geometry/graph_ops_message.c
@@ -1,0 +1,4 @@
+#include "geometry/graph_ops_message.h"
+
+/* Empty stub suite */
+const OperationSuite graph_ops_message = {0};

--- a/src/geometry/graph_ops_node.c
+++ b/src/geometry/graph_ops_node.c
@@ -1,0 +1,4 @@
+#include "geometry/graph_ops_node.h"
+
+/* Empty stub suite */
+const OperationSuite graph_ops_node = {0};

--- a/src/geometry/graph_ops_object_set.c
+++ b/src/geometry/graph_ops_object_set.c
@@ -1,0 +1,4 @@
+#include "geometry/graph_ops_object_set.h"
+
+/* Empty stub suite */
+const OperationSuite graph_ops_object_set = {0};

--- a/src/geometry/graph_ops_parallel_list.c
+++ b/src/geometry/graph_ops_parallel_list.c
@@ -1,0 +1,4 @@
+#include "geometry/graph_ops_parallel_list.h"
+
+/* Empty stub suite */
+const OperationSuite graph_ops_parallel_list = {0};

--- a/src/geometry/graph_ops_pointer.c
+++ b/src/geometry/graph_ops_pointer.c
@@ -1,0 +1,4 @@
+#include "geometry/graph_ops_pointer.h"
+
+/* Empty stub suite */
+const OperationSuite graph_ops_pointer = {0};

--- a/src/geometry/graph_ops_pointer_token.c
+++ b/src/geometry/graph_ops_pointer_token.c
@@ -1,0 +1,4 @@
+#include "geometry/graph_ops_pointer_token.h"
+
+/* Empty stub suite */
+const OperationSuite graph_ops_pointer_token = {0};

--- a/src/geometry/graph_ops_set.c
+++ b/src/geometry/graph_ops_set.c
@@ -1,0 +1,4 @@
+#include "geometry/graph_ops_set.h"
+
+/* Empty stub suite */
+const OperationSuite graph_ops_set = {0};

--- a/src/geometry/graph_ops_stencil.c
+++ b/src/geometry/graph_ops_stencil.c
@@ -1,0 +1,4 @@
+#include "geometry/graph_ops_stencil.h"
+
+/* Empty stub suite */
+const OperationSuite graph_ops_stencil = {0};

--- a/src/geometry/graph_ops_string.c
+++ b/src/geometry/graph_ops_string.c
@@ -1,0 +1,4 @@
+#include "geometry/graph_ops_string.h"
+
+/* Empty stub suite */
+const OperationSuite graph_ops_string = {0};

--- a/src/geometry/graph_ops_tensor_boolean.c
+++ b/src/geometry/graph_ops_tensor_boolean.c
@@ -1,0 +1,4 @@
+#include "geometry/graph_ops_tensor_boolean.h"
+
+/* Empty stub suite */
+const OperationSuite graph_ops_tensor_boolean = {0};

--- a/src/geometry/graph_ops_tensor_double.c
+++ b/src/geometry/graph_ops_tensor_double.c
@@ -1,0 +1,4 @@
+#include "geometry/graph_ops_tensor_double.h"
+
+/* Empty stub suite */
+const OperationSuite graph_ops_tensor_double = {0};

--- a/src/geometry/graph_ops_tensor_float.c
+++ b/src/geometry/graph_ops_tensor_float.c
@@ -1,0 +1,4 @@
+#include "geometry/graph_ops_tensor_float.h"
+
+/* Empty stub suite */
+const OperationSuite graph_ops_tensor_float = {0};

--- a/src/geometry/graph_ops_tensor_int.c
+++ b/src/geometry/graph_ops_tensor_int.c
@@ -1,0 +1,4 @@
+#include "geometry/graph_ops_tensor_int.h"
+
+/* Empty stub suite */
+const OperationSuite graph_ops_tensor_int = {0};

--- a/src/geometry/graph_ops_tensor_pointer.c
+++ b/src/geometry/graph_ops_tensor_pointer.c
@@ -1,0 +1,4 @@
+#include "geometry/graph_ops_tensor_pointer.h"
+
+/* Empty stub suite */
+const OperationSuite graph_ops_tensor_pointer = {0};

--- a/src/geometry/graph_ops_tensor_string.c
+++ b/src/geometry/graph_ops_tensor_string.c
@@ -1,0 +1,4 @@
+#include "geometry/graph_ops_tensor_string.h"
+
+/* Empty stub suite */
+const OperationSuite graph_ops_tensor_string = {0};

--- a/src/geometry/graph_ops_tensor_vector_boolean.c
+++ b/src/geometry/graph_ops_tensor_vector_boolean.c
@@ -1,0 +1,4 @@
+#include "geometry/graph_ops_tensor_vector_boolean.h"
+
+/* Empty stub suite */
+const OperationSuite graph_ops_tensor_vector_boolean = {0};

--- a/src/geometry/graph_ops_tensor_vector_double.c
+++ b/src/geometry/graph_ops_tensor_vector_double.c
@@ -1,0 +1,4 @@
+#include "geometry/graph_ops_tensor_vector_double.h"
+
+/* Empty stub suite */
+const OperationSuite graph_ops_tensor_vector_double = {0};

--- a/src/geometry/graph_ops_tensor_vector_float.c
+++ b/src/geometry/graph_ops_tensor_vector_float.c
@@ -1,0 +1,4 @@
+#include "geometry/graph_ops_tensor_vector_float.h"
+
+/* Empty stub suite */
+const OperationSuite graph_ops_tensor_vector_float = {0};

--- a/src/geometry/graph_ops_tensor_vector_int.c
+++ b/src/geometry/graph_ops_tensor_vector_int.c
@@ -1,0 +1,4 @@
+#include "geometry/graph_ops_tensor_vector_int.h"
+
+/* Empty stub suite */
+const OperationSuite graph_ops_tensor_vector_int = {0};

--- a/src/geometry/graph_ops_tensor_vector_pointer.c
+++ b/src/geometry/graph_ops_tensor_vector_pointer.c
@@ -1,0 +1,4 @@
+#include "geometry/graph_ops_tensor_vector_pointer.h"
+
+/* Empty stub suite */
+const OperationSuite graph_ops_tensor_vector_pointer = {0};

--- a/src/geometry/graph_ops_tensor_vector_string.c
+++ b/src/geometry/graph_ops_tensor_vector_string.c
@@ -1,0 +1,4 @@
+#include "geometry/graph_ops_tensor_vector_string.h"
+
+/* Empty stub suite */
+const OperationSuite graph_ops_tensor_vector_string = {0};

--- a/src/geometry/graph_ops_token.c
+++ b/src/geometry/graph_ops_token.c
@@ -1,0 +1,4 @@
+#include "geometry/graph_ops_token.h"
+
+/* Empty stub suite */
+const OperationSuite graph_ops_token = {0};

--- a/src/geometry/graph_ops_token_lock.c
+++ b/src/geometry/graph_ops_token_lock.c
@@ -1,0 +1,4 @@
+#include "geometry/graph_ops_token_lock.h"
+
+/* Empty stub suite */
+const OperationSuite graph_ops_token_lock = {0};

--- a/src/geometry/graph_ops_vector_boolean.c
+++ b/src/geometry/graph_ops_vector_boolean.c
@@ -1,0 +1,4 @@
+#include "geometry/graph_ops_vector_boolean.h"
+
+/* Empty stub suite */
+const OperationSuite graph_ops_vector_boolean = {0};

--- a/src/geometry/graph_ops_vector_double.c
+++ b/src/geometry/graph_ops_vector_double.c
@@ -1,0 +1,4 @@
+#include "geometry/graph_ops_vector_double.h"
+
+/* Empty stub suite */
+const OperationSuite graph_ops_vector_double = {0};

--- a/src/geometry/graph_ops_vector_float.c
+++ b/src/geometry/graph_ops_vector_float.c
@@ -1,0 +1,4 @@
+#include "geometry/graph_ops_vector_float.h"
+
+/* Empty stub suite */
+const OperationSuite graph_ops_vector_float = {0};

--- a/src/geometry/graph_ops_vector_int.c
+++ b/src/geometry/graph_ops_vector_int.c
@@ -1,0 +1,4 @@
+#include "geometry/graph_ops_vector_int.h"
+
+/* Empty stub suite */
+const OperationSuite graph_ops_vector_int = {0};

--- a/src/geometry/graph_ops_vector_pointer.c
+++ b/src/geometry/graph_ops_vector_pointer.c
@@ -1,0 +1,4 @@
+#include "geometry/graph_ops_vector_pointer.h"
+
+/* Empty stub suite */
+const OperationSuite graph_ops_vector_pointer = {0};

--- a/src/geometry/graph_ops_vector_string.c
+++ b/src/geometry/graph_ops_vector_string.c
@@ -1,0 +1,4 @@
+#include "geometry/graph_ops_vector_string.h"
+
+/* Empty stub suite */
+const OperationSuite graph_ops_vector_string = {0};


### PR DESCRIPTION
## Summary
- remove placeholder documentation
- generate stub headers and sources for every `NodeFeatureType`
- include all data type suites in `graph_ops_handler.h`
- map each feature type to its suite in `graph_ops_handler.c`

## Testing
- `cmake -S . -B build`
- `cmake --build build` *(fails: unknown type names and conflicting types)*
- `ctest --test-dir build --output-on-failure` *(fails: no executables built)*

------
https://chatgpt.com/codex/tasks/task_e_685ce6cb5848832ab968ab5c69fb736f