### PR TITLE
Add complex numbers module

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,3 +36,7 @@ add_test(NAME graph_ops_handler_test COMMAND graph_ops_handler_test)
 add_executable(iterative_solver_test tests/iterative_solver_test.c)
 target_link_libraries(iterative_solver_test geometry)
 add_test(NAME iterative_solver_test COMMAND iterative_solver_test)
+
+add_executable(complex_numbers_test tests/complex_numbers_test.c)
+target_link_libraries(complex_numbers_test geometry)
+add_test(NAME complex_numbers_test COMMAND complex_numbers_test)

--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ The library is structured in layers, from low-level backend execution to a high-
 ║ • histogram_normalization.h/c    (histogram aware normalization) ║
 ║ • envelopes.h/c                  (parametric and quantized ADSR) ║
 ║ • fft.h/c                         (FFT capabilities)             ║
+║ • complex_numbers.h               (2D vector complex arithmetic; add, sub, mul, div) ║
 ║ • synthesizer.h/c                 (signal generation core)       ║
 ║ • pidgeon_solver.h/c           (probabilistic pigeonhole solver) ║
 ║ • auxin_diffusion.h/c             (simulated plant exploration)  ║
@@ -156,6 +157,7 @@ outline of the main pieces, their pure mathematical roots and practical roles.
 | `execution_graph.h`       | Scheduler theory               | Executes dependent tasks in an ordered graph. |
 | `envelopes.h`             | Signal processing              | Parametric and quantized ADSR or custom envelope modeling. |
 | `fft.h`                   | Harmonic analysis              | Lightweight FFT implementation for spectral transforms. |
+| `complex_numbers.h`       | Complex analysis               | Vector-style complex numbers supporting add/sub/mul/div and polar conversion via Euler's formula. |
 | `cross_process_api.h`     | Operating Systems              | Cross-process messaging and synchronization primitives. |
 | `synthesizer.h`           | Signal processing              | Core oscillator for simple waveform generation. |
 | `pidgeon_solver.h`        | Probability theory             | Estimates collision likelihood when mapping many items into few buckets. |

--- a/include/geometry/complex_numbers.h
+++ b/include/geometry/complex_numbers.h
@@ -1,0 +1,76 @@
+#ifndef GEOMETRY_COMPLEX_NUMBERS_H
+#define GEOMETRY_COMPLEX_NUMBERS_H
+
+#include <stddef.h>
+#include <math.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * Simple complex number represented as a 2D vector (real, imag).
+ * Operations are implemented using Euler's formula
+ *     e^{iθ} = cos(θ) + i sin(θ)
+ * so that complex multiplication corresponds to rotating and
+ * scaling the underlying vector.
+ */
+typedef struct {
+    double real;
+    double imag;
+} ComplexNumber;
+
+// Construct from Cartesian components
+static inline ComplexNumber complex_from_cartesian(double real, double imag) {
+    ComplexNumber c; c.real = real; c.imag = imag; return c;
+}
+
+// Construct from polar coordinates using Euler's formula
+static inline ComplexNumber complex_from_polar(double r, double theta) {
+    ComplexNumber c; c.real = r * cos(theta); c.imag = r * sin(theta); return c;
+}
+
+// Add two complex numbers
+static inline ComplexNumber complex_add(ComplexNumber a, ComplexNumber b) {
+    return complex_from_cartesian(a.real + b.real, a.imag + b.imag);
+}
+
+// Multiply two complex numbers
+static inline ComplexNumber complex_mul(ComplexNumber a, ComplexNumber b) {
+    return complex_from_cartesian(a.real * b.real - a.imag * b.imag,
+                                  a.real * b.imag + a.imag * b.real);
+}
+
+// Subtract two complex numbers
+static inline ComplexNumber complex_sub(ComplexNumber a, ComplexNumber b) {
+    return complex_from_cartesian(a.real - b.real, a.imag - b.imag);
+}
+
+// Divide two complex numbers
+static inline ComplexNumber complex_div(ComplexNumber a, ComplexNumber b) {
+    double denom = b.real * b.real + b.imag * b.imag;
+    return complex_from_cartesian(
+        (a.real * b.real + a.imag * b.imag) / denom,
+        (a.imag * b.real - a.real * b.imag) / denom);
+}
+
+// Complex conjugate
+static inline ComplexNumber complex_conj(ComplexNumber a) {
+    return complex_from_cartesian(a.real, -a.imag);
+}
+
+// Magnitude (absolute value)
+static inline double complex_abs(ComplexNumber a) {
+    return sqrt(a.real * a.real + a.imag * a.imag);
+}
+
+// Convert to a raw 2D vector [real, imag]
+static inline void complex_to_vector(const ComplexNumber* c, double out[2]) {
+    out[0] = c->real; out[1] = c->imag;
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // GEOMETRY_COMPLEX_NUMBERS_H

--- a/tests/complex_numbers_test.c
+++ b/tests/complex_numbers_test.c
@@ -1,0 +1,36 @@
+#include "geometry/complex_numbers.h"
+#include <assert.h>
+#include <stdio.h>
+#include <math.h>
+
+int main(void) {
+    ComplexNumber a = complex_from_cartesian(1.0, 1.0);
+    ComplexNumber b = complex_from_polar(1.0, M_PI / 2.0);
+    ComplexNumber sum = complex_add(a, b);
+    assert(fabs(sum.real - 1.0) < 1e-9); // real component
+    assert(fabs(sum.imag - 2.0) < 1e-9); // imag component
+
+    ComplexNumber prod = complex_mul(a, b);
+    // a*(i) -> (1+i)*(0+1i) = -1+1i
+    assert(fabs(prod.real + 1.0) < 1e-9);
+    assert(fabs(prod.imag - 1.0) < 1e-9);
+
+    ComplexNumber diff = complex_sub(a, b);
+    assert(fabs(diff.real - 1.0) < 1e-9); // 1 - 0
+    assert(fabs(diff.imag - 0.0) < 1e-9); // 1 - 1
+
+    ComplexNumber quot = complex_div(a, b);
+    assert(fabs(quot.real - 1.0) < 1e-9); // (1+i)/i = 1 - i*(1)
+    assert(fabs(quot.imag + 1.0) < 1e-9);
+
+    ComplexNumber conj = complex_conj(a);
+    assert(conj.real == a.real && conj.imag == -a.imag);
+    assert(fabs(complex_abs(a) - sqrt(2.0)) < 1e-9);
+
+    double vec[2];
+    complex_to_vector(&prod, vec);
+    assert(fabs(vec[0] + 1.0) < 1e-9 && fabs(vec[1] - 1.0) < 1e-9);
+
+    printf("complex_numbers_test passed\n");
+    return 0;
+}


### PR DESCRIPTION
## Summary
- introduce `complex_numbers.h` for Euler formula complex arithmetic
- expose tests for complex number operations
- list the new module in README and add to table
- add `complex_numbers_test` to build system
- expand complex number functions and tests

## Testing
- `cmake -S . -B build` *(fails: errors in existing sources)*
- `cmake --build build` *(fails: unknown types in existing sources)*
- `gcc -Iinclude tests/complex_numbers_test.c -lm -o complex_numbers_test && ./complex_numbers_test`

------
https://chatgpt.com/codex/tasks/task_e_685cfb2fc54c832a8a5e842c3877956a