### PR TITLE
Add bitwise ops and containers

### DIFF
--- a/include/geometry/encoding_primitives.h
+++ b/include/geometry/encoding_primitives.h
@@ -1,0 +1,43 @@
+#ifndef GEOMETRY_ENCODING_PRIMITIVES_H
+#define GEOMETRY_ENCODING_PRIMITIVES_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Strided bit-level stream */
+typedef struct {
+    uint8_t* data;
+    size_t stride_bits;
+    size_t length_bits;
+} BitStrideStream;
+
+/* Simple byte-addressable field */
+typedef struct {
+    uint8_t* bytes;
+    size_t length_bytes;
+} ByteField;
+
+/* Arbitrary radix encoded value */
+typedef struct {
+    uint8_t* digits;
+    size_t length;
+    uint8_t base;
+    uint8_t is_balanced;
+} RadixEncodedValue;
+
+/* Palette-based pattern stream */
+typedef struct {
+    void** pattern_slots;
+    uint32_t* index_stream;
+    size_t pattern_count;
+} PatternPaletteStream;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* GEOMETRY_ENCODING_PRIMITIVES_H */

--- a/include/geometry/graph_ops.h
+++ b/include/geometry/graph_ops.h
@@ -60,6 +60,11 @@ typedef enum {
         NODE_FEATURE_TYPE_TENSOR_COMPLEX_DOUBLE = 49, // Tensor of complex numbers (double)
         NODE_FEATURE_TYPE_TENSOR_VECTOR_COMPLEX = 50, // Tensor of vectors of complex numbers (float)
         NODE_FEATURE_TYPE_TENSOR_VECTOR_COMPLEX_DOUBLE = 51, // Tensor of vectors of complex numbers (double)
+        NODE_FEATURE_TYPE_BITFIELD = 52, // Strided bitfield feature
+        NODE_FEATURE_TYPE_BYTEFIELD = 53, // Bytefield feature
+        NODE_FEATURE_TYPE_RADIX_ENCODING = 54, // Radix encoded value
+        NODE_FEATURE_TYPE_PATTERN_PALETTE_STREAM = 55, // Pattern palette stream
+        NODE_FEATURE_TYPE_ENCODING_ENGINE = 56, // Encoding engine dispatcher
         NODE_FEATURE_TYPE_COUNT
 } NodeFeatureType;
 
@@ -143,6 +148,14 @@ typedef void* (*graph_factorize_fn)(void* a, GraphOpRegion region);
 typedef void* (*graph_gcf_fn)(void* a, void* b, GraphOpRegion region);
 typedef void* (*graph_lcm_fn)(void* a, void* b, GraphOpRegion region);
 
+/* --- Bitwise Operations --- */
+typedef void* (*graph_bit_and_fn)(void* a, void* b, GraphOpRegion region);
+typedef void* (*graph_bit_or_fn)(void* a, void* b, GraphOpRegion region);
+typedef void* (*graph_bit_xor_fn)(void* a, void* b, GraphOpRegion region);
+typedef void* (*graph_bit_not_fn)(void* a, GraphOpRegion region);
+typedef void* (*graph_bit_shift_left_fn)(void* a, int shift, GraphOpRegion region);
+typedef void* (*graph_bit_shift_right_fn)(void* a, int shift, GraphOpRegion region);
+
 typedef enum {
     DIFFUSION_MODEL_AUXIN = 0,
     DIFFUSION_MODEL_SLIME_MOLD,
@@ -200,6 +213,15 @@ typedef struct {
     graph_diffuse_fn     diffuse;
 } GraphMathOps;
 
+typedef struct {
+    graph_bit_and_fn        bit_and;
+    graph_bit_or_fn         bit_or;
+    graph_bit_xor_fn        bit_xor;
+    graph_bit_not_fn        bit_not;
+    graph_bit_shift_left_fn shift_left;
+    graph_bit_shift_right_fn shift_right;
+} GraphBitOps;
+
 /* Suite of operations for a specific data-type container */
 typedef struct {
     OpTranslatePtrFn translate_ptr;
@@ -247,8 +269,9 @@ typedef struct {
     OpQuantileHistogramFn   quantile_histogram;
     OpRankOrderNormalizeFn  rank_order_normalize;
 
-    /* Extended mathematical operations */
+    /* Extended mathematical and bitwise operations */
     GraphMathOps math_ops;
+    GraphBitOps  bit_ops;
 } OperationSuite;
 
 

--- a/include/geometry/graph_ops_bitfield.h
+++ b/include/geometry/graph_ops_bitfield.h
@@ -1,0 +1,9 @@
+#ifndef GEOMETRY_GRAPH_OPS_BITFIELD_H
+#define GEOMETRY_GRAPH_OPS_BITFIELD_H
+
+#include "geometry/graph_ops.h"
+
+/* Stub operation suite for bitfield */
+extern const OperationSuite graph_ops_bitfield;
+
+#endif /* GEOMETRY_GRAPH_OPS_BITFIELD_H */

--- a/include/geometry/graph_ops_bytefield.h
+++ b/include/geometry/graph_ops_bytefield.h
@@ -1,0 +1,9 @@
+#ifndef GEOMETRY_GRAPH_OPS_BYTEFIELD_H
+#define GEOMETRY_GRAPH_OPS_BYTEFIELD_H
+
+#include "geometry/graph_ops.h"
+
+/* Stub operation suite for bytefield */
+extern const OperationSuite graph_ops_bytefield;
+
+#endif /* GEOMETRY_GRAPH_OPS_BYTEFIELD_H */

--- a/include/geometry/graph_ops_encoding_engine.h
+++ b/include/geometry/graph_ops_encoding_engine.h
@@ -1,0 +1,9 @@
+#ifndef GEOMETRY_GRAPH_OPS_ENCODING_ENGINE_H
+#define GEOMETRY_GRAPH_OPS_ENCODING_ENGINE_H
+
+#include "geometry/graph_ops.h"
+
+/* Stub operation suite for encoding engine */
+extern const OperationSuite graph_ops_encoding_engine;
+
+#endif /* GEOMETRY_GRAPH_OPS_ENCODING_ENGINE_H */

--- a/include/geometry/graph_ops_handler.h
+++ b/include/geometry/graph_ops_handler.h
@@ -60,6 +60,11 @@ extern "C" {
 #include "geometry/graph_ops_memory_map.h"
 #include "geometry/graph_ops_message.h"
 #include "geometry/graph_ops_custom.h"
+#include "geometry/graph_ops_bitfield.h"
+#include "geometry/graph_ops_bytefield.h"
+#include "geometry/graph_ops_radix_encoding.h"
+#include "geometry/graph_ops_pattern_palette_stream.h"
+#include "geometry/graph_ops_encoding_engine.h"
 
 /* Array of pointers to each suite; defined in graph_ops_handler.c */
 extern const OperationSuite* const OperationSuites[];

--- a/include/geometry/graph_ops_pattern_palette_stream.h
+++ b/include/geometry/graph_ops_pattern_palette_stream.h
@@ -1,0 +1,9 @@
+#ifndef GEOMETRY_GRAPH_OPS_PATTERN_PALETTE_STREAM_H
+#define GEOMETRY_GRAPH_OPS_PATTERN_PALETTE_STREAM_H
+
+#include "geometry/graph_ops.h"
+
+/* Stub operation suite for pattern palette stream */
+extern const OperationSuite graph_ops_pattern_palette_stream;
+
+#endif /* GEOMETRY_GRAPH_OPS_PATTERN_PALETTE_STREAM_H */

--- a/include/geometry/graph_ops_radix_encoding.h
+++ b/include/geometry/graph_ops_radix_encoding.h
@@ -1,0 +1,9 @@
+#ifndef GEOMETRY_GRAPH_OPS_RADIX_ENCODING_H
+#define GEOMETRY_GRAPH_OPS_RADIX_ENCODING_H
+
+#include "geometry/graph_ops.h"
+
+/* Stub operation suite for radix encoding */
+extern const OperationSuite graph_ops_radix_encoding;
+
+#endif /* GEOMETRY_GRAPH_OPS_RADIX_ENCODING_H */

--- a/src/geometry/graph_ops_bitfield.c
+++ b/src/geometry/graph_ops_bitfield.c
@@ -1,0 +1,84 @@
+#include "geometry/graph_ops_bitfield.h"
+#include "geometry/encoding_primitives.h"
+#include <stddef.h>
+
+static void* bitfield_and(void* a, void* b, GraphOpRegion region) {
+    (void)region;
+    BitStrideStream* A = (BitStrideStream*)a;
+    BitStrideStream* B = (BitStrideStream*)b;
+    size_t len = A->length_bits / 8;
+    if (B->length_bits / 8 < len) len = B->length_bits / 8;
+    for (size_t i = 0; i < len; ++i) {
+        A->data[i] &= B->data[i];
+    }
+    return a;
+}
+
+static void* bitfield_or(void* a, void* b, GraphOpRegion region) {
+    (void)region;
+    BitStrideStream* A = (BitStrideStream*)a;
+    BitStrideStream* B = (BitStrideStream*)b;
+    size_t len = A->length_bits / 8;
+    if (B->length_bits / 8 < len) len = B->length_bits / 8;
+    for (size_t i = 0; i < len; ++i) {
+        A->data[i] |= B->data[i];
+    }
+    return a;
+}
+
+static void* bitfield_xor(void* a, void* b, GraphOpRegion region) {
+    (void)region;
+    BitStrideStream* A = (BitStrideStream*)a;
+    BitStrideStream* B = (BitStrideStream*)b;
+    size_t len = A->length_bits / 8;
+    if (B->length_bits / 8 < len) len = B->length_bits / 8;
+    for (size_t i = 0; i < len; ++i) {
+        A->data[i] ^= B->data[i];
+    }
+    return a;
+}
+
+static void* bitfield_not(void* a, GraphOpRegion region) {
+    (void)region;
+    BitStrideStream* A = (BitStrideStream*)a;
+    size_t len = A->length_bits / 8;
+    for (size_t i = 0; i < len; ++i) {
+        A->data[i] = (uint8_t)(~A->data[i]);
+    }
+    return a;
+}
+
+static void* bitfield_shift_left(void* a, int shift, GraphOpRegion region) {
+    (void)region;
+    if (shift <= 0 || shift >= 8) return a;
+    BitStrideStream* A = (BitStrideStream*)a;
+    size_t len = A->length_bits / 8;
+    for (size_t i = 0; i < len; ++i) {
+        uint8_t next = (i + 1 < len) ? A->data[i + 1] : 0;
+        A->data[i] = (uint8_t)((A->data[i] << shift) | (next >> (8 - shift)));
+    }
+    return a;
+}
+
+static void* bitfield_shift_right(void* a, int shift, GraphOpRegion region) {
+    (void)region;
+    if (shift <= 0 || shift >= 8) return a;
+    BitStrideStream* A = (BitStrideStream*)a;
+    size_t len = A->length_bits / 8;
+    for (size_t i = len; i-- > 0;) {
+        uint8_t prev = (i > 0) ? A->data[i - 1] : 0;
+        A->data[i] = (uint8_t)((A->data[i] >> shift) | (prev << (8 - shift)));
+    }
+    return a;
+}
+
+const OperationSuite graph_ops_bitfield = {
+    .bit_ops = {
+        .bit_and   = bitfield_and,
+        .bit_or    = bitfield_or,
+        .bit_xor   = bitfield_xor,
+        .bit_not   = bitfield_not,
+        .shift_left  = bitfield_shift_left,
+        .shift_right = bitfield_shift_right
+    }
+};

--- a/src/geometry/graph_ops_bytefield.c
+++ b/src/geometry/graph_ops_bytefield.c
@@ -1,0 +1,78 @@
+#include "geometry/graph_ops_bytefield.h"
+#include "geometry/encoding_primitives.h"
+#include <stddef.h>
+
+static void* bytefield_and(void* a, void* b, GraphOpRegion region) {
+    (void)region;
+    ByteField* A = (ByteField*)a;
+    ByteField* B = (ByteField*)b;
+    size_t len = A->length_bytes < B->length_bytes ? A->length_bytes : B->length_bytes;
+    for (size_t i = 0; i < len; ++i) {
+        A->bytes[i] &= B->bytes[i];
+    }
+    return a;
+}
+
+static void* bytefield_or(void* a, void* b, GraphOpRegion region) {
+    (void)region;
+    ByteField* A = (ByteField*)a;
+    ByteField* B = (ByteField*)b;
+    size_t len = A->length_bytes < B->length_bytes ? A->length_bytes : B->length_bytes;
+    for (size_t i = 0; i < len; ++i) {
+        A->bytes[i] |= B->bytes[i];
+    }
+    return a;
+}
+
+static void* bytefield_xor(void* a, void* b, GraphOpRegion region) {
+    (void)region;
+    ByteField* A = (ByteField*)a;
+    ByteField* B = (ByteField*)b;
+    size_t len = A->length_bytes < B->length_bytes ? A->length_bytes : B->length_bytes;
+    for (size_t i = 0; i < len; ++i) {
+        A->bytes[i] ^= B->bytes[i];
+    }
+    return a;
+}
+
+static void* bytefield_not(void* a, GraphOpRegion region) {
+    (void)region;
+    ByteField* A = (ByteField*)a;
+    for (size_t i = 0; i < A->length_bytes; ++i) {
+        A->bytes[i] = (uint8_t)(~A->bytes[i]);
+    }
+    return a;
+}
+
+static void* bytefield_shift_left(void* a, int shift, GraphOpRegion region) {
+    (void)region;
+    if (shift <= 0 || shift >= 8) return a;
+    ByteField* A = (ByteField*)a;
+    for (size_t i = 0; i < A->length_bytes; ++i) {
+        uint8_t next = (i + 1 < A->length_bytes) ? A->bytes[i + 1] : 0;
+        A->bytes[i] = (uint8_t)((A->bytes[i] << shift) | (next >> (8 - shift)));
+    }
+    return a;
+}
+
+static void* bytefield_shift_right(void* a, int shift, GraphOpRegion region) {
+    (void)region;
+    if (shift <= 0 || shift >= 8) return a;
+    ByteField* A = (ByteField*)a;
+    for (size_t i = A->length_bytes; i-- > 0;) {
+        uint8_t prev = (i > 0) ? A->bytes[i - 1] : 0;
+        A->bytes[i] = (uint8_t)((A->bytes[i] >> shift) | (prev << (8 - shift)));
+    }
+    return a;
+}
+
+const OperationSuite graph_ops_bytefield = {
+    .bit_ops = {
+        .bit_and   = bytefield_and,
+        .bit_or    = bytefield_or,
+        .bit_xor   = bytefield_xor,
+        .bit_not   = bytefield_not,
+        .shift_left  = bytefield_shift_left,
+        .shift_right = bytefield_shift_right
+    }
+};

--- a/src/geometry/graph_ops_encoding_engine.c
+++ b/src/geometry/graph_ops_encoding_engine.c
@@ -1,0 +1,4 @@
+#include "geometry/graph_ops_encoding_engine.h"
+
+/* Empty stub suite */
+const OperationSuite graph_ops_encoding_engine = {0};

--- a/src/geometry/graph_ops_handler.c
+++ b/src/geometry/graph_ops_handler.c
@@ -54,7 +54,12 @@ const OperationSuite* const OperationSuites[NODE_FEATURE_TYPE_COUNT] = {
     &graph_ops_tensor_complex,     /* NODE_FEATURE_TYPE_TENSOR_COMPLEX */
     &graph_ops_tensor_complex_double,/* NODE_FEATURE_TYPE_TENSOR_COMPLEX_DOUBLE */
     &graph_ops_tensor_vector_complex,/* NODE_FEATURE_TYPE_TENSOR_VECTOR_COMPLEX */
-    &graph_ops_tensor_vector_complex_double/* NODE_FEATURE_TYPE_TENSOR_VECTOR_COMPLEX_DOUBLE */
+    &graph_ops_tensor_vector_complex_double,/* NODE_FEATURE_TYPE_TENSOR_VECTOR_COMPLEX_DOUBLE */
+    &graph_ops_bitfield,            /* NODE_FEATURE_TYPE_BITFIELD */
+    &graph_ops_bytefield,           /* NODE_FEATURE_TYPE_BYTEFIELD */
+    &graph_ops_radix_encoding,      /* NODE_FEATURE_TYPE_RADIX_ENCODING */
+    &graph_ops_pattern_palette_stream, /* NODE_FEATURE_TYPE_PATTERN_PALETTE_STREAM */
+    &graph_ops_encoding_engine      /* NODE_FEATURE_TYPE_ENCODING_ENGINE */
 };
 
 const OperationSuite* get_operation_suite(NodeFeatureType type) {

--- a/src/geometry/graph_ops_pattern_palette_stream.c
+++ b/src/geometry/graph_ops_pattern_palette_stream.c
@@ -1,0 +1,4 @@
+#include "geometry/graph_ops_pattern_palette_stream.h"
+
+/* Empty stub suite */
+const OperationSuite graph_ops_pattern_palette_stream = {0};

--- a/src/geometry/graph_ops_radix_encoding.c
+++ b/src/geometry/graph_ops_radix_encoding.c
@@ -1,0 +1,78 @@
+#include "geometry/graph_ops_radix_encoding.h"
+#include "geometry/encoding_primitives.h"
+#include <stddef.h>
+
+static void* radix_and(void* a, void* b, GraphOpRegion region) {
+    (void)region;
+    RadixEncodedValue* A = (RadixEncodedValue*)a;
+    RadixEncodedValue* B = (RadixEncodedValue*)b;
+    size_t len = A->length < B->length ? A->length : B->length;
+    for (size_t i = 0; i < len; ++i) {
+        A->digits[i] &= B->digits[i];
+    }
+    return a;
+}
+
+static void* radix_or(void* a, void* b, GraphOpRegion region) {
+    (void)region;
+    RadixEncodedValue* A = (RadixEncodedValue*)a;
+    RadixEncodedValue* B = (RadixEncodedValue*)b;
+    size_t len = A->length < B->length ? A->length : B->length;
+    for (size_t i = 0; i < len; ++i) {
+        A->digits[i] |= B->digits[i];
+    }
+    return a;
+}
+
+static void* radix_xor(void* a, void* b, GraphOpRegion region) {
+    (void)region;
+    RadixEncodedValue* A = (RadixEncodedValue*)a;
+    RadixEncodedValue* B = (RadixEncodedValue*)b;
+    size_t len = A->length < B->length ? A->length : B->length;
+    for (size_t i = 0; i < len; ++i) {
+        A->digits[i] ^= B->digits[i];
+    }
+    return a;
+}
+
+static void* radix_not(void* a, GraphOpRegion region) {
+    (void)region;
+    RadixEncodedValue* A = (RadixEncodedValue*)a;
+    for (size_t i = 0; i < A->length; ++i) {
+        A->digits[i] = (uint8_t)(~A->digits[i]);
+    }
+    return a;
+}
+
+static void* radix_shift_left(void* a, int shift, GraphOpRegion region) {
+    (void)region;
+    if (shift <= 0 || shift >= 8) return a;
+    RadixEncodedValue* A = (RadixEncodedValue*)a;
+    for (size_t i = 0; i < A->length; ++i) {
+        uint8_t next = (i + 1 < A->length) ? A->digits[i + 1] : 0;
+        A->digits[i] = (uint8_t)((A->digits[i] << shift) | (next >> (8 - shift)));
+    }
+    return a;
+}
+
+static void* radix_shift_right(void* a, int shift, GraphOpRegion region) {
+    (void)region;
+    if (shift <= 0 || shift >= 8) return a;
+    RadixEncodedValue* A = (RadixEncodedValue*)a;
+    for (size_t i = A->length; i-- > 0;) {
+        uint8_t prev = (i > 0) ? A->digits[i - 1] : 0;
+        A->digits[i] = (uint8_t)((A->digits[i] >> shift) | (prev << (8 - shift)));
+    }
+    return a;
+}
+
+const OperationSuite graph_ops_radix_encoding = {
+    .bit_ops = {
+        .bit_and   = radix_and,
+        .bit_or    = radix_or,
+        .bit_xor   = radix_xor,
+        .bit_not   = radix_not,
+        .shift_left  = radix_shift_left,
+        .shift_right = radix_shift_right
+    }
+};


### PR DESCRIPTION
## Summary
- add bitwise operation hooks to `OperationSuite`
- implement bit/byte/radix bitwise operation suites
- wire in bitwise operations for new containers

## Testing
- `cmake ..`
- `make -j$(nproc)` *(fails: incomplete types)*
- `ctest --output-on-failure` *(no executables built)*


------
https://chatgpt.com/codex/tasks/task_e_685d0ec0803c832ab02340e75e551d84