### PR TITLE
Add memory backend scaffolding

### DIFF
--- a/include/assembly_backend/memory_ops.h
+++ b/include/assembly_backend/memory_ops.h
@@ -1,0 +1,32 @@
+#ifndef ASSEMBLY_BACKEND_MEMORY_OPS_H
+#define ASSEMBLY_BACKEND_MEMORY_OPS_H
+
+#include <stdint.h>
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct __attribute__((packed)) DiffBlockHeader {
+    uint32_t magic;
+    uint8_t  version;
+    uint16_t type_id;
+    uint8_t  flags;
+    uint32_t payload_bytes;
+    uint32_t pointer_index_offset;
+    uint32_t metadata_offset;
+    uint16_t stride;
+    uint64_t block_id;
+} DiffBlockHeader;
+
+void* mg_encode_block(const void* raw_data, size_t size_bytes, uint16_t type_id, uint8_t flags);
+void* mg_decode_block(const void* encoded_block, size_t* out_payload_size);
+void  mg_tensor_compare_64x64(const void* block_a, const void* block_b, float* out_diff_tensor);
+const DiffBlockHeader* mg_peek_header(const void* block);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ASSEMBLY_BACKEND_MEMORY_OPS_H */

--- a/src/assembly_backend/decode.s
+++ b/src/assembly_backend/decode.s
@@ -1,0 +1,8 @@
+# Placeholder assembly implementation for mg_decode_block
+# This file can be extended with architecture specific routines.
+
+.global mg_decode_block
+mg_decode_block:
+    # Stub: simply returns the input pointer in rdi
+    mov %rdi, %rax
+    ret

--- a/src/assembly_backend/encode.s
+++ b/src/assembly_backend/encode.s
@@ -1,0 +1,8 @@
+# Placeholder assembly implementation for mg_encode_block
+# This file can be extended with architecture specific routines.
+
+.global mg_encode_block
+mg_encode_block:
+    # Stub: simply returns 0
+    xor %rax, %rax
+    ret

--- a/src/assembly_backend/init.c
+++ b/src/assembly_backend/init.c
@@ -1,0 +1,6 @@
+#include "assembly_backend/memory_ops.h"
+
+/* Initialization placeholder for the memory graph backend. */
+void assembly_backend_init(void) {
+    /* Currently no initialization logic. */
+}

--- a/src/assembly_backend/memory_ops.c
+++ b/src/assembly_backend/memory_ops.c
@@ -1,0 +1,35 @@
+#include "assembly_backend/memory_ops.h"
+
+/*
+ * Stub implementations for the differentiable memory graph backend.
+ * These are placeholders and do not perform real memory management yet.
+ */
+
+void* mg_encode_block(const void* raw_data, size_t size_bytes, uint16_t type_id, uint8_t flags) {
+    (void)raw_data;
+    (void)size_bytes;
+    (void)type_id;
+    (void)flags;
+    // Memory allocation is disallowed in this repository. Returning NULL for now.
+    return NULL;
+}
+
+void* mg_decode_block(const void* encoded_block, size_t* out_payload_size) {
+    if (out_payload_size) *out_payload_size = 0;
+    // No actual decoding performed.
+    return (void*)encoded_block;
+}
+
+void mg_tensor_compare_64x64(const void* block_a, const void* block_b, float* out_diff_tensor) {
+    (void)block_a;
+    (void)block_b;
+    if (out_diff_tensor) {
+        for (size_t i = 0; i < 64 * 64; ++i) {
+            out_diff_tensor[i] = 0.0f;
+        }
+    }
+}
+
+const DiffBlockHeader* mg_peek_header(const void* block) {
+    return (const DiffBlockHeader*)block;
+}


### PR DESCRIPTION
## Summary
- introduce assembly backend scaffolding
- add memory graph block APIs
- provide placeholder assembly routines

## Testing
- `cmake --build build` *(fails: conflicting types for `differentiator_reset`)*
- `ctest --test-dir build --output-on-failure` *(fails: executables not found)*

------
https://chatgpt.com/codex/tasks/task_e_685defb765a8832aafbe72da1dc88cde