### PR TITLE
Create thread_ops module and move lock helpers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,7 @@ set(C_SOURCES
     src/assembly_backend/simd/simd_impl_sse2.c
     src/assembly_backend/simd/simd_impl_fallback.c
     src/assembly_backend/simd/memory_intrinsics.c
+    src/assembly_backend/thread_ops.c
     src/assembly_backend/core.c
 )
 add_library(geometry ${C_SOURCES})

--- a/include/assembly_backend/memory_ops.h
+++ b/include/assembly_backend/memory_ops.h
@@ -3,6 +3,7 @@
 
 #include <stdint.h>
 #include <stddef.h>
+#include "assembly_backend/thread_ops.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/assembly_backend/thread_ops.h
+++ b/include/assembly_backend/thread_ops.h
@@ -1,0 +1,28 @@
+#ifndef ASSEMBLY_BACKEND_THREAD_OPS_H
+#define ASSEMBLY_BACKEND_THREAD_OPS_H
+
+#include <stddef.h>
+#include "geometry/guardian_platform.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void thread_ops_init(size_t capacity);
+void thread_ops_register_mutex(long long token, mutex_t* mutex);
+mutex_t* thread_ops_get_mutex(long long token);
+void thread_ops_register_thread(long long token, guardian_thread_handle_t thread);
+guardian_thread_handle_t thread_ops_get_thread(long long token);
+void thread_ops_register_pointer(long long token, void* ptr);
+void* thread_ops_get_pointer(long long token);
+
+int guardian_try_lock(TokenGuardian* g, unsigned long lock_token);
+void guardian_lock(TokenGuardian* g, unsigned long lock_token);
+void guardian_unlock(TokenGuardian* g, unsigned long lock_token);
+int guardian_is_locked(TokenGuardian* g, unsigned long lock_token);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ASSEMBLY_BACKEND_THREAD_OPS_H */

--- a/include/geometry/utils.h
+++ b/include/geometry/utils.h
@@ -36,6 +36,7 @@ typedef unsigned char boolean;
 #include <stdint.h>
 
 #include "geometry/guardian_platform.h"
+#include "assembly_backend/thread_ops.h"
 
 #include "geometry/dag.h"
 #include "geometry/stencil.h"
@@ -431,10 +432,6 @@ TokenGuardian* guardian_initialize(TokenGuardian* parent, size_t num_threads);
 GuardianToken* guardian_create_pointer_token(TokenGuardian* g, void* ptr, NodeFeatureType type);
 GuardianToken* guardian_create_lock_token(TokenGuardian* g);
 boolean guardian_lock_with_timeout(TokenGuardian* g, GuardianToken guardian_lock_token, int duration, boolean reentrant);
-int guardian_try_lock(TokenGuardian* g, unsigned long lock_token);
-void guardian_lock(TokenGuardian* g, unsigned long lock_token);
-void guardian_unlock(TokenGuardian* g, unsigned long lock_token);
-int guardian_is_locked(TokenGuardian* g, unsigned long lock_token);
 void* guardian_dereference_object(TokenGuardian* g, unsigned long pointer_token);
 
 TokenGuardian* ___guardian_create_internal_(void);

--- a/src/assembly_backend/thread_ops.c
+++ b/src/assembly_backend/thread_ops.c
@@ -1,0 +1,160 @@
+#include "assembly_backend/thread_ops.h"
+#include "assembly_backend/core.h"
+#include <string.h>
+
+#ifndef THREAD_OPS_DEFAULT_CAPACITY
+#define THREAD_OPS_DEFAULT_CAPACITY 1024
+#endif
+
+typedef struct {
+    long long token;
+    mutex_t* mutex;
+    guardian_thread_handle_t thread;
+    void* pointer;
+    int used;
+} ThreadOpsEntry;
+
+static ThreadOpsEntry* entries = NULL;
+static size_t entry_capacity = 0;
+static size_t entry_count = 0;
+static mutex_t* entries_lock = NULL;
+
+static int find_entry(long long token) {
+    for (size_t i = 0; i < entry_count; ++i) {
+        if (entries[i].used && entries[i].token == token) {
+            return (int)i;
+        }
+    }
+    return -1;
+}
+
+void thread_ops_init(size_t capacity) {
+    if (entries) return;
+    if (capacity == 0) capacity = THREAD_OPS_DEFAULT_CAPACITY;
+    entries = (ThreadOpsEntry*)mg_alloc(sizeof(ThreadOpsEntry) * capacity);
+    if (!entries) return;
+    memset(entries, 0, sizeof(ThreadOpsEntry) * capacity);
+    entry_capacity = capacity;
+    entry_count = 0;
+    entries_lock = guardian_mutex_init();
+}
+
+static ThreadOpsEntry* allocate_entry(long long token) {
+    if (!entries) thread_ops_init(0);
+    if (entry_count >= entry_capacity) {
+        return NULL;
+    }
+    ThreadOpsEntry* e = &entries[entry_count++];
+    memset(e, 0, sizeof(ThreadOpsEntry));
+    e->used = 1;
+    e->token = token;
+    return e;
+}
+
+void thread_ops_register_mutex(long long token, mutex_t* mutex) {
+    if (!entries) thread_ops_init(0);
+    guardian_mutex_lock(entries_lock);
+    int idx = find_entry(token);
+    ThreadOpsEntry* e = NULL;
+    if (idx >= 0) {
+        e = &entries[idx];
+    } else {
+        e = allocate_entry(token);
+    }
+    if (e) {
+        e->mutex = mutex;
+    }
+    guardian_mutex_unlock(entries_lock);
+}
+
+mutex_t* thread_ops_get_mutex(long long token) {
+    if (!entries) return NULL;
+    guardian_mutex_lock(entries_lock);
+    int idx = find_entry(token);
+    mutex_t* mtx = (idx >= 0) ? entries[idx].mutex : NULL;
+    guardian_mutex_unlock(entries_lock);
+    return mtx;
+}
+
+void thread_ops_register_thread(long long token, guardian_thread_handle_t thread) {
+    if (!entries) thread_ops_init(0);
+    guardian_mutex_lock(entries_lock);
+    int idx = find_entry(token);
+    ThreadOpsEntry* e = NULL;
+    if (idx >= 0) {
+        e = &entries[idx];
+    } else {
+        e = allocate_entry(token);
+    }
+    if (e) {
+        e->thread = thread;
+    }
+    guardian_mutex_unlock(entries_lock);
+}
+
+guardian_thread_handle_t thread_ops_get_thread(long long token) {
+    if (!entries) return (guardian_thread_handle_t)0;
+    guardian_mutex_lock(entries_lock);
+    int idx = find_entry(token);
+    guardian_thread_handle_t t = (idx >= 0) ? entries[idx].thread : (guardian_thread_handle_t)0;
+    guardian_mutex_unlock(entries_lock);
+    return t;
+}
+
+void thread_ops_register_pointer(long long token, void* ptr) {
+    if (!entries) thread_ops_init(0);
+    guardian_mutex_lock(entries_lock);
+    int idx = find_entry(token);
+    ThreadOpsEntry* e = NULL;
+    if (idx >= 0) {
+        e = &entries[idx];
+    } else {
+        e = allocate_entry(token);
+    }
+    if (e) {
+        e->pointer = ptr;
+    }
+    guardian_mutex_unlock(entries_lock);
+}
+
+void* thread_ops_get_pointer(long long token) {
+    if (!entries) return NULL;
+    guardian_mutex_lock(entries_lock);
+    int idx = find_entry(token);
+    void* p = (idx >= 0) ? entries[idx].pointer : NULL;
+    guardian_mutex_unlock(entries_lock);
+    return p;
+}
+
+int guardian_try_lock(TokenGuardian* g, unsigned long lock_token) {
+    (void)g;
+    mutex_t* mutex = thread_ops_get_mutex((long long)lock_token);
+    if (!mutex) return 0;
+    return guardian_mutex_trylock(mutex);
+}
+
+void guardian_lock(TokenGuardian* g, unsigned long lock_token) {
+    (void)g;
+    mutex_t* mutex = thread_ops_get_mutex((long long)lock_token);
+    if (!mutex) return;
+    guardian_mutex_lock(mutex);
+}
+
+void guardian_unlock(TokenGuardian* g, unsigned long lock_token) {
+    (void)g;
+    mutex_t* mutex = thread_ops_get_mutex((long long)lock_token);
+    if (!mutex) return;
+    guardian_mutex_unlock(mutex);
+}
+
+int guardian_is_locked(TokenGuardian* g, unsigned long lock_token) {
+    (void)g;
+    mutex_t* mutex = thread_ops_get_mutex((long long)lock_token);
+    if (!mutex) return 0;
+    if (guardian_mutex_trylock(mutex)) {
+        guardian_mutex_unlock(mutex);
+        return 0;
+    }
+    return 1;
+}
+

--- a/src/geometry/utils.c
+++ b/src/geometry/utils.c
@@ -871,46 +871,6 @@ GuardianToken guardian_create_token(
     return token;
 }
 
-// === Friendly Lock Functions ===
-
-// Try to acquire a lock using a token
-int guardian_try_lock(TokenGuardian* g, unsigned long lock_token) {
-    if (!g || lock_token == 0) return 0; // 0 for failure
-    mutex_t* mutex = (mutex_t*)___guardian_deref_neighbor_internal_(g, lock_token, 0, NULL);
-    if (!mutex) return 0; // 0 for failure
-    return guardian_mutex_trylock(mutex); // 1 for success, 0 for failure
-}
-
-// Acquire a lock using a token
-void guardian_lock(TokenGuardian* g, unsigned long lock_token) {
-    if (!g || lock_token == 0) return;
-    mutex_t* mutex = (mutex_t*)___guardian_deref_neighbor_internal_(g, lock_token, 0, NULL);
-    if (!mutex) return;
-    guardian_mutex_lock(mutex);
-}
-
-// Release a lock using a token
-void guardian_unlock(TokenGuardian* g, unsigned long lock_token) {
-    if (!g || lock_token == 0) return;
-    mutex_t* mutex = (mutex_t*)___guardian_deref_neighbor_internal_(g, lock_token, 0, NULL);
-    if (!mutex) return;
-    guardian_mutex_unlock(mutex);
-}
-
-// Check if a lock is held using a token
-int guardian_is_locked(TokenGuardian* g, unsigned long lock_token) {
-    if (!g || lock_token == 0) return 0;
-    mutex_t* mutex = (mutex_t*)___guardian_deref_neighbor_internal_(g, lock_token, 0, NULL);
-    if (!mutex) return 0; // Cannot determine, assume not locked
-    // Attempt to lock and immediately unlock.
-    if (guardian_mutex_trylock(mutex)) {
-        // We got the lock, so it wasn't locked.
-        guardian_mutex_unlock(mutex);
-        return 0; // Not locked
-    }
-    return 1; // Was locked
-}
-
 // === Object Dereferencer ===
 
 // Exchange a token for the object a pointer is pointing to


### PR DESCRIPTION
## Summary
- add `thread_ops` header/source for mapping tokens to locks, threads and pointers
- include `thread_ops` in `memory_ops`
- expose `thread_ops` through utils and drop inline lock helpers
- wire new source file into CMake build

## Testing
- `cmake ..`
- `make -j$(nproc)` *(fails: implicit declarations and other compile errors)*
- `ctest --output-on-failure` *(fails: build produced no test executables)*

------
https://chatgpt.com/codex/tasks/task_e_685f812ff6d0832a81ef3ad063c7dbb7